### PR TITLE
fix: add WINBOOL type

### DIFF
--- a/src/precomp/common.hpp
+++ b/src/precomp/common.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+typedef int WINBOOL;
+
 namespace Ghidra {
 typedef void* pointer;
 typedef void* pointer32;


### PR DESCRIPTION
Adds missing WINBOOL type in a predictable location