### PR TITLE
resolve #52: include strings header file

### DIFF
--- a/src/OpenSHC/string-literals.hpp
+++ b/src/OpenSHC/string-literals.hpp
@@ -1,0 +1,9482 @@
+/**
+  This file contains the strings from the read-only (.rdata) memory of the original binary.
+  These strings were used as a literal somewhere in the source, hence `char const * const`.
+  The STRING annotations help reccmp-reccmp identify the correct usage of the string.
+*/
+
+// STRING: STRONGHOLDCRUSADER 0x0059e830
+char const* const s_bad_allocation_0059e830 = "bad allocation";
+
+// STRING: STRONGHOLDCRUSADER 0x0059e8a0
+char const* const SFX_BuildingsAreOnFireSire = "General_Warning16.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x0059e8b8
+char const* const SFX_WeLostControlOfAGatehouse = "General_Warning19.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x0059e8d0
+char const* const s_ponds_sketch_tgx_0059e8d0 = "ponds_sketch.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x0059e8e4
+char const* const s_dancing_bear_sketch_tgx_0059e8e4 = "dancing_bear_sketch.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x0059e8fc
+char const* const s_statue_sketch_tgx_0059e8fc = "statue_sketch.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x0059e910
+char const* const s_dog_cage_sketch_tgx_0059e910 = "dog_cage_sketch.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x0059e924
+char const* const s_ducking_stool_sketch_tgx_0059e924 = "ducking_stool_sketch.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x0059e940
+char const* const s_chopping_block_sketch_tgx_0059e940 = "chopping_block_sketch.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x0059e95c
+char const* const s_stretching_rack_sketch_tgx_0059e95c = "stretching_rack_sketch.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x0059e978
+char const* const s_dungeon_sketch_tgx_0059e978 = "dungeon_sketch.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x0059e98c
+char const* const s_gibbet_sketch_tgx_0059e98c = "gibbet_sketch.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x0059e9a0
+char const* const s_stake_sketch_tgx_0059e9a0 = "stake_sketch.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x0059e9b4
+char const* const s_cess_pit_sketch_tgx_0059e9b4 = "cess_pit_sketch.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x0059e9c8
+char const* const s_waterpot_sketch_tgx_0059e9c8 = "waterpot_sketch.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x0059e9dc
+char const* const s_killing_pits_sketch_tgx_0059e9dc = "killing_pits_sketch.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x0059e9f4
+char const* const s_gardens_sketch_tgx_0059e9f4 = "gardens_sketch.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x0059ea08
+char const* const s_maypole_sketch_tgx_0059ea08 = "maypole_sketch.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x0059ea1c
+char const* const s_stocks_sketch_tgx_0059ea1c = "stocks_sketch.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x0059ea30
+char const* const s_gallows_sketch_tgx_0059ea30 = "gallows_sketch.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x0059ea44
+char const* const s_tower_sketch_tgx_0059ea44 = "tower_sketch.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x0059ea58
+char const* const s_campfire_sketch_tgx_0059ea58 = "campfire_sketch.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x0059ea6c
+char const* const s_keep_sketch_tgx_0059ea6c = "keep_sketch.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x0059ea7c
+char const* const s_church_sketch_tgx_0059ea7c = "church_sketch.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x0059ea90
+char const* const s_stables_sketch_tgx_0059ea90 = "stables_sketch.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x0059eaa4
+char const* const s_mill_sketch_tgx_0059eaa4 = "mill_sketch.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x0059eab4
+char const* const s_dairy_sketch_tgx_0059eab4 = "dairy_sketch.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x0059eac8
+char const* const s_fruit_sketch_tgx_0059eac8 = "fruit_sketch.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x0059eadc
+char const* const s_hop_sketch_tgx_0059eadc = "hop_sketch.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x0059eaec
+char const* const s_wheat_sketch_tgx_0059eaec = "wheat_sketch.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x0059eb00
+char const* const s_oil_smelter_sketch_tgx_0059eb00 = "oil_smelter_sketch.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x0059eb18
+char const* const s_well_sketch_tgx_0059eb18 = "well_sketch.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x0059eb28
+char const* const s_tunnelors_guild_sketch_tgx_0059eb28 = "tunnelors_guild_sketch.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x0059eb44
+char const* const s_healers_sketch_tgx_0059eb44 = "healers_sketch.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x0059eb58
+char const* const s_inn_sketch_tgx_0059eb58 = "inn_sketch.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x0059eb68
+char const* const s_quarry_sketch_tgx_0059eb68 = "quarry_sketch.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x0059eb7c
+char const* const s_bakery_sketch_tgx_0059eb7c = "bakery_sketch.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x0059eb90
+char const* const s_tanner_building_sketch_tgx_0059eb90 = "tanner_building_sketch.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x0059ebac
+char const* const s_pole_sketch_tgx_0059ebac = "pole_sketch.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x0059ebbc
+char const* const s_bsmith_sketch_tgx_0059ebbc = "bsmith_sketch.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x0059ebd0
+char const* const s_fletcher_building_sketch_tgx_0059ebd0 = "fletcher_building_sketch.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x0059ebf0
+char const* const s_hunter_hut_sketch_tgx_0059ebf0 = "hunter_hut_sketch.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x0059ec08
+char const* const s_pitch_sketch_tgx_0059ec08 = "pitch_sketch.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x0059ec1c
+char const* const s_iron_sketch_tgx_0059ec1c = "iron_sketch.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x0059ec2c
+char const* const s_woodcutter_hut_sketch_tgx_0059ec2c = "woodcutter_hut_sketch.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x0059ec48
+char const* const s_house_sketch_tgx_0059ec48 = "house_sketch.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x0059ec5c
+char const* const s_st105_bear_cave_bik_0059ec5c = "st105_bear_cave.bik";
+
+// STRING: STRONGHOLDCRUSADER 0x0059ec70
+char const* const s_st104_pond_bik_0059ec70 = "st104_pond.bik";
+
+// STRING: STRONGHOLDCRUSADER 0x0059ec80
+char const* const s_st103_dancing_bear_bik_0059ec80 = "st103_dancing_bear.bik";
+
+// STRING: STRONGHOLDCRUSADER 0x0059ec98
+char const* const s_st102_bee_hive_bik_0059ec98 = "st102_bee_hive.bik";
+
+// STRING: STRONGHOLDCRUSADER 0x0059ecac
+char const* const s_st101_shrine_bik_0059ecac = "st101_shrine.bik";
+
+// STRING: STRONGHOLDCRUSADER 0x0059ecc0
+char const* const s_st100_statue_bik_0059ecc0 = "st100_statue.bik";
+
+// STRING: STRONGHOLDCRUSADER 0x0059ecd4
+char const* const s_st99_dog_cage_bik_0059ecd4 = "st99_dog_cage.bik";
+
+// STRING: STRONGHOLDCRUSADER 0x0059ece8
+char const* const s_st98_dunking_stool_bik_0059ece8 = "st98_dunking_stool.bik";
+
+// STRING: STRONGHOLDCRUSADER 0x0059ed00
+char const* const s_st97_chopping_block_bik_0059ed00 = "st97_chopping_block.bik";
+
+// STRING: STRONGHOLDCRUSADER 0x0059ed18
+char const* const s_st96_rack_flogging_bik_0059ed18 = "st96_rack_flogging.bik";
+
+// STRING: STRONGHOLDCRUSADER 0x0059ed30
+char const* const s_st95_rack_stretching_bik_0059ed30 = "st95_rack_stretching.bik";
+
+// STRING: STRONGHOLDCRUSADER 0x0059ed4c
+char const* const s_st94_dungeon_bik_0059ed4c = "st94_dungeon.bik";
+
+// STRING: STRONGHOLDCRUSADER 0x0059ed60
+char const* const s_st93_gibbet_bik_0059ed60 = "st93_gibbet.bik";
+
+// STRING: STRONGHOLDCRUSADER 0x0059ed70
+char const* const s_st92_burning_stake_bik_0059ed70 = "st92_burning_stake.bik";
+
+// STRING: STRONGHOLDCRUSADER 0x0059ed88
+char const* const s_st91_cess_pit_bik_0059ed88 = "st91_cess_pit.bik";
+
+// STRING: STRONGHOLDCRUSADER 0x0059ed9c
+char const* const s_st85_tunnel_construction_bik_0059ed9c = "st85_tunnel_construction.bik";
+
+// STRING: STRONGHOLDCRUSADER 0x0059edbc
+char const* const s_st84_portable_shield_bik_0059edbc = "st84_portable_shield.bik";
+
+// STRING: STRONGHOLDCRUSADER 0x0059edd8
+char const* const s_st83_battering_ram_bik_0059edd8 = "st83_battering_ram.bik";
+
+// STRING: STRONGHOLDCRUSADER 0x0059edf0
+char const* const s_st82_siege_tower_bik_0059edf0 = "st82_siege_tower.bik";
+
+// STRING: STRONGHOLDCRUSADER 0x0059ee08
+char const* const s_st81_trebuchet_bik_0059ee08 = "st81_trebuchet.bik";
+
+// STRING: STRONGHOLDCRUSADER 0x0059ee1c
+char const* const s_st80_catapult_bik_0059ee1c = "st80_catapult.bik";
+
+// STRING: STRONGHOLDCRUSADER 0x0059ee30
+char const* const s_st78_tower5_bik_0059ee30 = "st78_tower5.bik";
+
+// STRING: STRONGHOLDCRUSADER 0x0059ee40
+char const* const s_st77_tower4_bik_0059ee40 = "st77_tower4.bik";
+
+// STRING: STRONGHOLDCRUSADER 0x0059ee50
+char const* const s_st76_tower3_bik_0059ee50 = "st76_tower3.bik";
+
+// STRING: STRONGHOLDCRUSADER 0x0059ee60
+char const* const s_st75_tower2_bik_0059ee60 = "st75_tower2.bik";
+
+// STRING: STRONGHOLDCRUSADER 0x0059ee70
+char const* const s_st74_tower1_bik_0059ee70 = "st74_tower1.bik";
+
+// STRING: STRONGHOLDCRUSADER 0x0059ee80
+char const* const s_st73_keepdoor_bik_0059ee80 = "st73_keepdoor.bik";
+
+// STRING: STRONGHOLDCRUSADER 0x0059ee94
+char const* const s_st72_keepdoor_right_bik_0059ee94 = "st72_keepdoor_right.bik";
+
+// STRING: STRONGHOLDCRUSADER 0x0059eeac
+char const* const s_st71_keepdoor_left_bik_0059eeac = "st71_keepdoor_left.bik";
+
+// STRING: STRONGHOLDCRUSADER 0x0059eec4
+char const* const s_st68_pitch_ditch_bik_0059eec4 = "st68_pitch_ditch.bik";
+
+// STRING: STRONGHOLDCRUSADER 0x0059eedc
+char const* const s_st67_killing_pit_bik_0059eedc = "st67_killing_pit.bik";
+
+// STRING: STRONGHOLDCRUSADER 0x0059eef4
+char const* const s_st66_garden_bik_0059eef4 = "st66_garden.bik";
+
+// STRING: STRONGHOLDCRUSADER 0x0059ef04
+char const* const s_st65_maypole_bik_0059ef04 = "st65_maypole.bik";
+
+// STRING: STRONGHOLDCRUSADER 0x0059ef18
+char const* const s_st63_stocks_bik_0059ef18 = "st63_stocks.bik";
+
+// STRING: STRONGHOLDCRUSADER 0x0059ef28
+char const* const s_st62_gallows_bik_0059ef28 = "st62_gallows.bik";
+
+// STRING: STRONGHOLDCRUSADER 0x0059ef3c
+char const* const s_st61_tower_bik_0059ef3c = "st61_tower.bik";
+
+// STRING: STRONGHOLDCRUSADER 0x0059ef4c
+char const* const s_st60_gatehouse_bik_0059ef4c = "st60_gatehouse.bik";
+
+// STRING: STRONGHOLDCRUSADER 0x0059ef60
+char const* const s_st59_paradeground_tun_bik_0059ef60 = "st59_paradeground_tun.bik";
+
+// STRING: STRONGHOLDCRUSADER 0x0059ef7c
+char const* const s_st58_paradeground_hvy_bik_0059ef7c = "st58_paradeground_hvy.bik";
+
+// STRING: STRONGHOLDCRUSADER 0x0059ef98
+char const* const s_st57_paradeground_lgt_bik_0059ef98 = "st57_paradeground_lgt.bik";
+
+// STRING: STRONGHOLDCRUSADER 0x0059efb4
+char const* const s_st56_paradeground_miss_bik_0059efb4 = "st56_paradeground_miss.bik";
+
+// STRING: STRONGHOLDCRUSADER 0x0059efd0
+char const* const s_st55_campground_bik_0059efd0 = "st55_campground.bik";
+
+// STRING: STRONGHOLDCRUSADER 0x0059efe4
+char const* const s_st53_paradeground_eng_bik_0059efe4 = "st53_paradeground_eng.bik";
+
+// STRING: STRONGHOLDCRUSADER 0x0059f000
+char const* const s_st52_signpost_bik_0059f000 = "st52_signpost.bik";
+
+// STRING: STRONGHOLDCRUSADER 0x0059f014
+char const* const s_st51_paradeground_oil_bik_0059f014 = "st51_paradeground_oil.bik";
+
+// STRING: STRONGHOLDCRUSADER 0x0059f030
+char const* const s_st50_tunnel_entrance_bik_0059f030 = "st50_tunnel_entrance.bik";
+
+// STRING: STRONGHOLDCRUSADER 0x0059f04c
+char const* const s_st49_drawbridge_bik_0059f04c = "st49_drawbridge.bik";
+
+// STRING: STRONGHOLDCRUSADER 0x0059f060
+char const* const s_st48_gate_postern_bik_0059f060 = "st48_gate_postern.bik";
+
+// STRING: STRONGHOLDCRUSADER 0x0059f078
+char const* const s_st47_gate_wood_bik_0059f078 = "st47_gate_wood.bik";
+
+// STRING: STRONGHOLDCRUSADER 0x0059f08c
+char const* const s_st46_gate_inner_bik_0059f08c = "st46_gate_inner.bik";
+
+// STRING: STRONGHOLDCRUSADER 0x0059f0a0
+char const* const s_st45_gate_main_bik_0059f0a0 = "st45_gate_main.bik";
+
+// STRING: STRONGHOLDCRUSADER 0x0059f0b4
+char const* const s_st44_keep5_bik_0059f0b4 = "st44_keep5.bik";
+
+// STRING: STRONGHOLDCRUSADER 0x0059f0c4
+char const* const s_st43_keep4_bik_0059f0c4 = "st43_keep4.bik";
+
+// STRING: STRONGHOLDCRUSADER 0x0059f0d4
+char const* const s_st42_keep3_bik_0059f0d4 = "st42_keep3.bik";
+
+// STRING: STRONGHOLDCRUSADER 0x0059f0e4
+char const* const s_st41_keep2_bik_0059f0e4 = "st41_keep2.bik";
+
+// STRING: STRONGHOLDCRUSADER 0x0059f0f4
+char const* const s_st40_keep1_bik_0059f0f4 = "st40_keep1.bik";
+
+// STRING: STRONGHOLDCRUSADER 0x0059f104
+char const* const s_st36_church1_bik_0059f104 = "st36_church1.bik";
+
+// STRING: STRONGHOLDCRUSADER 0x0059f118
+char const* const s_st35_stables_bik_0059f118 = "st35_stables.bik";
+
+// STRING: STRONGHOLDCRUSADER 0x0059f12c
+char const* const s_st34_mill_bik_0059f12c = "st34_mill.bik";
+
+// STRING: STRONGHOLDCRUSADER 0x0059f13c
+char const* const s_st33_cattlefarm_bik_0059f13c = "st33_cattlefarm.bik";
+
+// STRING: STRONGHOLDCRUSADER 0x0059f150
+char const* const s_st32_applefarm_bik_0059f150 = "st32_applefarm.bik";
+
+// STRING: STRONGHOLDCRUSADER 0x0059f164
+char const* const s_st31_hopsfarm_bik_0059f164 = "st31_hopsfarm.bik";
+
+// STRING: STRONGHOLDCRUSADER 0x0059f178
+char const* const s_st30_wheatfarm_bik_0059f178 = "st30_wheatfarm.bik";
+
+// STRING: STRONGHOLDCRUSADER 0x0059f18c
+char const* const s_st28_oil_smelter_bik_0059f18c = "st28_oil_smelter.bik";
+
+// STRING: STRONGHOLDCRUSADER 0x0059f1a4
+char const* const s_st26_tradepost_bik_0059f1a4 = "st26_tradepost.bik";
+
+// STRING: STRONGHOLDCRUSADER 0x0059f1b8
+char const* const s_st25_tunnellers_guild_bik_0059f1b8 = "st25_tunnellers_guild.bik";
+
+// STRING: STRONGHOLDCRUSADER 0x0059f1d4
+char const* const s_st24_engineers_guild_bik_0059f1d4 = "st24_engineers_guild.bik";
+
+// STRING: STRONGHOLDCRUSADER 0x0059f1f0
+char const* const s_st23_healer_bik_0059f1f0 = "st23_healer.bik";
+
+// STRING: STRONGHOLDCRUSADER 0x0059f200
+char const* const s_st22_inn_bik_0059f200 = "st22_inn.bik";
+
+// STRING: STRONGHOLDCRUSADER 0x0059f210
+char const* const s_st21_quarrypile_bik_0059f210 = "st21_quarrypile.bik";
+
+// STRING: STRONGHOLDCRUSADER 0x0059f224
+char const* const s_st20_quarry_bik_0059f224 = "st20_quarry.bik";
+
+// STRING: STRONGHOLDCRUSADER 0x0059f234
+char const* const s_st19_granary_bik_0059f234 = "st19_granary.bik";
+
+// STRING: STRONGHOLDCRUSADER 0x0059f248
+char const* const s_st18_brewers_workshop_bik_0059f248 = "st18_brewers_workshop.bik";
+
+// STRING: STRONGHOLDCRUSADER 0x0059f264
+char const* const s_st17_bakers_workshop_bik_0059f264 = "st17_bakers_workshop.bik";
+
+// STRING: STRONGHOLDCRUSADER 0x0059f280
+char const* const s_st16_tanners_workshop_bik_0059f280 = "st16_tanners_workshop.bik";
+
+// STRING: STRONGHOLDCRUSADER 0x0059f29c
+char const* const s_st15_armourers_workshop_bik_0059f29c = "st15_armourers_workshop.bik";
+
+// STRING: STRONGHOLDCRUSADER 0x0059f2b8
+char const* const s_st14_poleturners_workshop_bik_0059f2b8 = "st14_poleturners_workshop.bik";
+
+// STRING: STRONGHOLDCRUSADER 0x0059f2d8
+char const* const s_st13_blacksmiths_workshop_bik_0059f2d8 = "st13_blacksmiths_workshop.bik";
+
+// STRING: STRONGHOLDCRUSADER 0x0059f2f8
+char const* const s_st12_fletchers_workshop_bik_0059f2f8 = "st12_fletchers_workshop.bik";
+
+// STRING: STRONGHOLDCRUSADER 0x0059f314
+char const* const s_st11_armoury_bik_0059f314 = "st11_armoury.bik";
+
+// STRING: STRONGHOLDCRUSADER 0x0059f328
+char const* const s_st10_goods_yard_bik_0059f328 = "st10_goods_yard.bik";
+
+// STRING: STRONGHOLDCRUSADER 0x0059f33c
+char const* const s_st08_barracks_bik_0059f33c = "st08_barracks.bik";
+
+// STRING: STRONGHOLDCRUSADER 0x0059f350
+char const* const s_st07_hunters_hut_bik_0059f350 = "st07_hunters_hut.bik";
+
+// STRING: STRONGHOLDCRUSADER 0x0059f368
+char const* const s_st06_pitch_digger_bik_0059f368 = "st06_pitch_digger.bik";
+
+// STRING: STRONGHOLDCRUSADER 0x0059f380
+char const* const s_st05_iron_mine_bik_0059f380 = "st05_iron_mine.bik";
+
+// STRING: STRONGHOLDCRUSADER 0x0059f394
+char const* const s_st04_oxen_base_bik_0059f394 = "st04_oxen_base.bik";
+
+// STRING: STRONGHOLDCRUSADER 0x0059f3a8
+char const* const s_st03_woodcutters_hut_bik_0059f3a8 = "st03_woodcutters_hut.bik";
+
+// STRING: STRONGHOLDCRUSADER 0x0059f3c4
+char const* const s_st02_house_bik_0059f3c4 = "st02_house.bik";
+
+// STRING: STRONGHOLDCRUSADER 0x0059f3d4
+char const* const s_st105_bear_cave_hlp_0059f3d4 = "st105_bear_cave.hlp";
+
+// STRING: STRONGHOLDCRUSADER 0x0059f3e8
+char const* const s_st99_dog_cage_hlp_0059f3e8 = "st99_dog_cage.hlp";
+
+// STRING: STRONGHOLDCRUSADER 0x0059f3fc
+char const* const s_st85_tunnel_construction_hlp_0059f3fc = "st85_tunnel_construction.hlp";
+
+// STRING: STRONGHOLDCRUSADER 0x0059f41c
+char const* const s_st84_portable_shield_hlp_0059f41c = "st84_portable_shield.hlp";
+
+// STRING: STRONGHOLDCRUSADER 0x0059f438
+char const* const s_st83_battering_ram_hlp_0059f438 = "st83_battering_ram.hlp";
+
+// STRING: STRONGHOLDCRUSADER 0x0059f450
+char const* const s_st82_siege_tower_hlp_0059f450 = "st82_siege_tower.hlp";
+
+// STRING: STRONGHOLDCRUSADER 0x0059f468
+char const* const s_st81_trebuchet_hlp_0059f468 = "st81_trebuchet.hlp";
+
+// STRING: STRONGHOLDCRUSADER 0x0059f47c
+char const* const s_st80_catapult_hlp_0059f47c = "st80_catapult.hlp";
+
+// STRING: STRONGHOLDCRUSADER 0x0059f490
+char const* const s_st78_tower5_hlp_0059f490 = "st78_tower5.hlp";
+
+// STRING: STRONGHOLDCRUSADER 0x0059f4a0
+char const* const s_st77_tower4_hlp_0059f4a0 = "st77_tower4.hlp";
+
+// STRING: STRONGHOLDCRUSADER 0x0059f4b0
+char const* const s_st76_tower3_hlp_0059f4b0 = "st76_tower3.hlp";
+
+// STRING: STRONGHOLDCRUSADER 0x0059f4c0
+char const* const s_st75_tower2_hlp_0059f4c0 = "st75_tower2.hlp";
+
+// STRING: STRONGHOLDCRUSADER 0x0059f4d0
+char const* const s_st74_tower1_hlp_0059f4d0 = "st74_tower1.hlp";
+
+// STRING: STRONGHOLDCRUSADER 0x0059f4e0
+char const* const s_st73_keepdoor_hlp_0059f4e0 = "st73_keepdoor.hlp";
+
+// STRING: STRONGHOLDCRUSADER 0x0059f4f4
+char const* const s_st72_keepdoor_right_hlp_0059f4f4 = "st72_keepdoor_right.hlp";
+
+// STRING: STRONGHOLDCRUSADER 0x0059f50c
+char const* const s_st71_keepdoor_left_hlp_0059f50c = "st71_keepdoor_left.hlp";
+
+// STRING: STRONGHOLDCRUSADER 0x0059f524
+char const* const s_st70_water_pot_hlp_0059f524 = "st70_water_pot.hlp";
+
+// STRING: STRONGHOLDCRUSADER 0x0059f538
+char const* const s_st68_pitch_ditch_hlp_0059f538 = "st68_pitch_ditch.hlp";
+
+// STRING: STRONGHOLDCRUSADER 0x0059f550
+char const* const s_st67_killing_pit_hlp_0059f550 = "st67_killing_pit.hlp";
+
+// STRING: STRONGHOLDCRUSADER 0x0059f568
+char const* const s_st65_good_things_hlp_0059f568 = "st65_good_things.hlp";
+
+// STRING: STRONGHOLDCRUSADER 0x0059f580
+char const* const s_st62_bad_things_hlp_0059f580 = "st62_bad_things.hlp";
+
+// STRING: STRONGHOLDCRUSADER 0x0059f594
+char const* const s_st61_tower_hlp_0059f594 = "st61_tower.hlp";
+
+// STRING: STRONGHOLDCRUSADER 0x0059f5a4
+char const* const s_st55_campground_hlp_0059f5a4 = "st55_campground.hlp";
+
+// STRING: STRONGHOLDCRUSADER 0x0059f5b8
+char const* const s_st52_signpost_hlp_0059f5b8 = "st52_signpost.hlp";
+
+// STRING: STRONGHOLDCRUSADER 0x0059f5cc
+char const* const s_st50_tunnel_entrance_hlp_0059f5cc = "st50_tunnel_entrance.hlp";
+
+// STRING: STRONGHOLDCRUSADER 0x0059f5e8
+char const* const s_st49_drawbridge_hlp_0059f5e8 = "st49_drawbridge.hlp";
+
+// STRING: STRONGHOLDCRUSADER 0x0059f5fc
+char const* const s_st60_gatehouse_hlp_0059f5fc = "st60_gatehouse.hlp";
+
+// STRING: STRONGHOLDCRUSADER 0x0059f610
+char const* const s_st40_keep_hlp_0059f610 = "st40_keep.hlp";
+
+// STRING: STRONGHOLDCRUSADER 0x0059f620
+char const* const s_st36_church_hlp_0059f620 = "st36_church.hlp";
+
+// STRING: STRONGHOLDCRUSADER 0x0059f630
+char const* const s_st35_stables_hlp_0059f630 = "st35_stables.hlp";
+
+// STRING: STRONGHOLDCRUSADER 0x0059f644
+char const* const s_st34_mill_hlp_0059f644 = "st34_mill.hlp";
+
+// STRING: STRONGHOLDCRUSADER 0x0059f654
+char const* const s_st33_cattlefarm_hlp_0059f654 = "st33_cattlefarm.hlp";
+
+// STRING: STRONGHOLDCRUSADER 0x0059f668
+char const* const s_st32_applefarm_hlp_0059f668 = "st32_applefarm.hlp";
+
+// STRING: STRONGHOLDCRUSADER 0x0059f67c
+char const* const s_st31_hopsfarm_hlp_0059f67c = "st31_hopsfarm.hlp";
+
+// STRING: STRONGHOLDCRUSADER 0x0059f690
+char const* const s_st30_wheatfarm_hlp_0059f690 = "st30_wheatfarm.hlp";
+
+// STRING: STRONGHOLDCRUSADER 0x0059f6a4
+char const* const s_st28_oil_smelter_hlp_0059f6a4 = "st28_oil_smelter.hlp";
+
+// STRING: STRONGHOLDCRUSADER 0x0059f6bc
+char const* const s_st27_well_hlp_0059f6bc = "st27_well.hlp";
+
+// STRING: STRONGHOLDCRUSADER 0x0059f6cc
+char const* const s_st26_tradepost_hlp_0059f6cc = "st26_tradepost.hlp";
+
+// STRING: STRONGHOLDCRUSADER 0x0059f6e0
+char const* const s_st25_tunnellers_guild_hlp_0059f6e0 = "st25_tunnellers_guild.hlp";
+
+// STRING: STRONGHOLDCRUSADER 0x0059f6fc
+char const* const s_st24_engineers_guild_hlp_0059f6fc = "st24_engineers_guild.hlp";
+
+// STRING: STRONGHOLDCRUSADER 0x0059f718
+char const* const s_st23_healer_hlp_0059f718 = "st23_healer.hlp";
+
+// STRING: STRONGHOLDCRUSADER 0x0059f728
+char const* const s_st22_inn_hlp_0059f728 = "st22_inn.hlp";
+
+// STRING: STRONGHOLDCRUSADER 0x0059f738
+char const* const s_st21_quarrypile_hlp_0059f738 = "st21_quarrypile.hlp";
+
+// STRING: STRONGHOLDCRUSADER 0x0059f74c
+char const* const s_st20_quarry_hlp_0059f74c = "st20_quarry.hlp";
+
+// STRING: STRONGHOLDCRUSADER 0x0059f75c
+char const* const s_st19_granary_hlp_0059f75c = "st19_granary.hlp";
+
+// STRING: STRONGHOLDCRUSADER 0x0059f770
+char const* const s_st18_brewers_workshop_hlp_0059f770 = "st18_brewers_workshop.hlp";
+
+// STRING: STRONGHOLDCRUSADER 0x0059f78c
+char const* const s_st17_bakers_workshop_hlp_0059f78c = "st17_bakers_workshop.hlp";
+
+// STRING: STRONGHOLDCRUSADER 0x0059f7a8
+char const* const s_st16_tanners_workshop_hlp_0059f7a8 = "st16_tanners_workshop.hlp";
+
+// STRING: STRONGHOLDCRUSADER 0x0059f7c4
+char const* const s_st15_armourers_workshop_hlp_0059f7c4 = "st15_armourers_workshop.hlp";
+
+// STRING: STRONGHOLDCRUSADER 0x0059f7e0
+char const* const s_st14_poleturners_workshop_hlp_0059f7e0 = "st14_poleturners_workshop.hlp";
+
+// STRING: STRONGHOLDCRUSADER 0x0059f800
+char const* const s_st13_blacksmiths_workshop_hlp_0059f800 = "st13_blacksmiths_workshop.hlp";
+
+// STRING: STRONGHOLDCRUSADER 0x0059f820
+char const* const s_st12_fletchers_workshop_hlp_0059f820 = "st12_fletchers_workshop.hlp";
+
+// STRING: STRONGHOLDCRUSADER 0x0059f83c
+char const* const s_st11_armoury_hlp_0059f83c = "st11_armoury.hlp";
+
+// STRING: STRONGHOLDCRUSADER 0x0059f850
+char const* const s_st10_goods_yard_hlp_0059f850 = "st10_goods_yard.hlp";
+
+// STRING: STRONGHOLDCRUSADER 0x0059f864
+char const* const s_st09_barracks_hlp_0059f864 = "st09_barracks.hlp";
+
+// STRING: STRONGHOLDCRUSADER 0x0059f878
+char const* const s_st08_mercenary_post_hlp_0059f878 = "st08_mercenary_post.hlp";
+
+// STRING: STRONGHOLDCRUSADER 0x0059f890
+char const* const s_st07_hunters_hut_hlp_0059f890 = "st07_hunters_hut.hlp";
+
+// STRING: STRONGHOLDCRUSADER 0x0059f8a8
+char const* const s_st06_pitch_digger_hlp_0059f8a8 = "st06_pitch_digger.hlp";
+
+// STRING: STRONGHOLDCRUSADER 0x0059f8c0
+char const* const s_st05_iron_mine_hlp_0059f8c0 = "st05_iron_mine.hlp";
+
+// STRING: STRONGHOLDCRUSADER 0x0059f8d4
+char const* const s_st04_oxen_base_hlp_0059f8d4 = "st04_oxen_base.hlp";
+
+// STRING: STRONGHOLDCRUSADER 0x0059f8e8
+char const* const s_st03_woodcutters_hut_hlp_0059f8e8 = "st03_woodcutters_hut.hlp";
+
+// STRING: STRONGHOLDCRUSADER 0x0059f904
+char const* const s_st02_house_hlp_0059f904 = "st02_house.hlp";
+
+// STRING: STRONGHOLDCRUSADER 0x0059f914
+char const* const s_chimp66_fireeater_bik_0059f914 = "chimp66_fireeater.bik";
+
+// STRING: STRONGHOLDCRUSADER 0x0059f92c
+char const* const s_chimp65_juggler_bik_0059f92c = "chimp65_juggler.bik";
+
+// STRING: STRONGHOLDCRUSADER 0x0059f940
+char const* const s_chimp64_child_bik_0059f940 = "chimp64_child.bik";
+
+// STRING: STRONGHOLDCRUSADER 0x0059f954
+char const* const s_chimp63_mother_bik_0059f954 = "chimp63_mother.bik";
+
+// STRING: STRONGHOLDCRUSADER 0x0059f968
+char const* const s_chimp62_chicken_bik_0059f968 = "chimp62_chicken.bik";
+
+// STRING: STRONGHOLDCRUSADER 0x0059f97c
+char const* const s_chimp61_ballista_bik_0059f97c = "chimp61_ballista.bik";
+
+// STRING: STRONGHOLDCRUSADER 0x0059f994
+char const* const s_chimp60_portable_shield_bik_0059f994 = "chimp60_portable_shield.bik";
+
+// STRING: STRONGHOLDCRUSADER 0x0059f9b0
+char const* const s_chimp59_battering_ram_bik_0059f9b0 = "chimp59_battering_ram.bik";
+
+// STRING: STRONGHOLDCRUSADER 0x0059f9cc
+char const* const s_chimp58_siege_tower_bik_0059f9cc = "chimp58_siege_tower.bik";
+
+// STRING: STRONGHOLDCRUSADER 0x0059f9e4
+char const* const s_chimp57_jester_bik_0059f9e4 = "chimp57_jester.bik";
+
+// STRING: STRONGHOLDCRUSADER 0x0059f9f8
+char const* const s_chimp56_lady_bik_0059f9f8 = "chimp56_lady.bik";
+
+// STRING: STRONGHOLDCRUSADER 0x0059fa0c
+char const* const s_chimp55_lord_bik_0059fa0c = "chimp55_lord.bik";
+
+// STRING: STRONGHOLDCRUSADER 0x0059fa20
+char const* const s_chimp52_dog_bik_0059fa20 = "chimp52_dog.bik";
+
+// STRING: STRONGHOLDCRUSADER 0x0059fa30
+char const* const s_chimp51_cow_bik_0059fa30 = "chimp51_cow.bik";
+
+// STRING: STRONGHOLDCRUSADER 0x0059fa40
+char const* const s_chimp50_siege_tent_bik_0059fa40 = "chimp50_siege_tent.bik";
+
+// STRING: STRONGHOLDCRUSADER 0x0059fa58
+char const* const s_chimp49_seagull_bik_0059fa58 = "chimp49_seagull.bik";
+
+// STRING: STRONGHOLDCRUSADER 0x0059fa6c
+char const* const s_chimp48_crow_bik_0059fa6c = "chimp48_crow.bik";
+
+// STRING: STRONGHOLDCRUSADER 0x0059fa80
+char const* const s_chimp47_bear_bik_0059fa80 = "chimp47_bear.bik";
+
+// STRING: STRONGHOLDCRUSADER 0x0059fa94
+char const* const s_chimp46_rabbit_bik_0059fa94 = "chimp46_rabbit.bik";
+
+// STRING: STRONGHOLDCRUSADER 0x0059faa8
+char const* const s_chimp45_wolf_bik_0059faa8 = "chimp45_wolf.bik";
+
+// STRING: STRONGHOLDCRUSADER 0x0059fabc
+char const* const s_chimp44_deer_bik_0059fabc = "chimp44_deer.bik";
+
+// STRING: STRONGHOLDCRUSADER 0x0059fad0
+char const* const s_chimp43_trader_horse_bik_0059fad0 = "chimp43_trader_horse.bik";
+
+// STRING: STRONGHOLDCRUSADER 0x0059faec
+char const* const s_chimp42_trader_bik_0059faec = "chimp42_trader.bik";
+
+// STRING: STRONGHOLDCRUSADER 0x0059fb00
+char const* const s_chimp41_mangonel_bik_0059fb00 = "chimp41_mangonel.bik";
+
+// STRING: STRONGHOLDCRUSADER 0x0059fb18
+char const* const s_chimp40_trebuchet_bik_0059fb18 = "chimp40_trebuchet.bik";
+
+// STRING: STRONGHOLDCRUSADER 0x0059fb30
+char const* const s_chimp39_catapult_bik_0059fb30 = "chimp39_catapult.bik";
+
+// STRING: STRONGHOLDCRUSADER 0x0059fb48
+char const* const s_chimp37_monk_bik_0059fb48 = "chimp37_monk.bik";
+
+// STRING: STRONGHOLDCRUSADER 0x0059fb5c
+char const* const s_chimp36_innkeeper_bik_0059fb5c = "chimp36_innkeeper.bik";
+
+// STRING: STRONGHOLDCRUSADER 0x0059fb74
+char const* const s_chimp35_drunkard_bik_0059fb74 = "chimp35_drunkard.bik";
+
+// STRING: STRONGHOLDCRUSADER 0x0059fb8c
+char const* const s_chimp34_healer_bik_0059fb8c = "chimp34_healer.bik";
+
+// STRING: STRONGHOLDCRUSADER 0x0059fba0
+char const* const s_chimp33_preist_bik_0059fba0 = "chimp33_preist.bik";
+
+// STRING: STRONGHOLDCRUSADER 0x0059fbb4
+char const* const s_chimp32_miner2_bik_0059fbb4 = "chimp32_miner2.bik";
+
+// STRING: STRONGHOLDCRUSADER 0x0059fbc8
+char const* const s_chimp31_miner1_bik_0059fbc8 = "chimp31_miner1.bik";
+
+// STRING: STRONGHOLDCRUSADER 0x0059fbdc
+char const* const s_chimp30_engineer_bik_0059fbdc = "chimp30_engineer.bik";
+
+// STRING: STRONGHOLDCRUSADER 0x0059fbf4
+char const* const s_chimp29_ladderman_bik_0059fbf4 = "chimp29_ladderman.bik";
+
+// STRING: STRONGHOLDCRUSADER 0x0059fc0c
+char const* const s_chimp28_knight_bik_0059fc0c = "chimp28_knight.bik";
+
+// STRING: STRONGHOLDCRUSADER 0x0059fc20
+char const* const s_chimp27_swordsman_bik_0059fc20 = "chimp27_swordsman.bik";
+
+// STRING: STRONGHOLDCRUSADER 0x0059fc38
+char const* const s_chimp26_maceman_bik_0059fc38 = "chimp26_maceman.bik";
+
+// STRING: STRONGHOLDCRUSADER 0x0059fc4c
+char const* const s_chimp25_pikeman_bik_0059fc4c = "chimp25_pikeman.bik";
+
+// STRING: STRONGHOLDCRUSADER 0x0059fc60
+char const* const s_chimp24_spearman_bik_0059fc60 = "chimp24_spearman.bik";
+
+// STRING: STRONGHOLDCRUSADER 0x0059fc78
+char const* const s_chimp23_xbowman_bik_0059fc78 = "chimp23_xbowman.bik";
+
+// STRING: STRONGHOLDCRUSADER 0x0059fc8c
+char const* const s_chimp22_archer_bik_0059fc8c = "chimp22_archer.bik";
+
+// STRING: STRONGHOLDCRUSADER 0x0059fca0
+char const* const s_chimp21_tanner_bik_0059fca0 = "chimp21_tanner.bik";
+
+// STRING: STRONGHOLDCRUSADER 0x0059fcb4
+char const* const s_chimp20_armourer_bik_0059fcb4 = "chimp20_armourer.bik";
+
+// STRING: STRONGHOLDCRUSADER 0x0059fccc
+char const* const s_chimp19_blacksmith_bik_0059fccc = "chimp19_blacksmith.bik";
+
+// STRING: STRONGHOLDCRUSADER 0x0059fce4
+char const* const s_chimp18_poleturner_bik_0059fce4 = "chimp18_poleturner.bik";
+
+// STRING: STRONGHOLDCRUSADER 0x0059fcfc
+char const* const s_chimp17_brewer_bik_0059fcfc = "chimp17_brewer.bik";
+
+// STRING: STRONGHOLDCRUSADER 0x0059fd10
+char const* const s_chimp16_baker_bik_0059fd10 = "chimp16_baker.bik";
+
+// STRING: STRONGHOLDCRUSADER 0x0059fd24
+char const* const s_chimp15_miller_bik_0059fd24 = "chimp15_miller.bik";
+
+// STRING: STRONGHOLDCRUSADER 0x0059fd38
+char const* const s_chimp14_farmer_cattle_bik_0059fd38 = "chimp14_farmer_cattle.bik";
+
+// STRING: STRONGHOLDCRUSADER 0x0059fd54
+char const* const s_chimp13_farmer_apples_bik_0059fd54 = "chimp13_farmer_apples.bik";
+
+// STRING: STRONGHOLDCRUSADER 0x0059fd70
+char const* const s_chimp12_farmer_hops_bik_0059fd70 = "chimp12_farmer_hops.bik";
+
+// STRING: STRONGHOLDCRUSADER 0x0059fd88
+char const* const s_chimp11_farmer_wheat_bik_0059fd88 = "chimp11_farmer_wheat.bik";
+
+// STRING: STRONGHOLDCRUSADER 0x0059fda4
+char const* const s_chimp10_pitchman_bik_0059fda4 = "chimp10_pitchman.bik";
+
+// STRING: STRONGHOLDCRUSADER 0x0059fdbc
+char const* const s_chimp09_quarry_ox_bik_0059fdbc = "chimp09_quarry_ox.bik";
+
+// STRING: STRONGHOLDCRUSADER 0x0059fdd4
+char const* const s_chimp08_quarry_grunt_bik_0059fdd4 = "chimp08_quarry_grunt.bik";
+
+// STRING: STRONGHOLDCRUSADER 0x0059fdf0
+char const* const s_chimp07_quarry_mason_bik_0059fdf0 = "chimp07_quarry_mason.bik";
+
+// STRING: STRONGHOLDCRUSADER 0x0059fe0c
+char const* const s_chimp06_hunter_bik_0059fe0c = "chimp06_hunter.bik";
+
+// STRING: STRONGHOLDCRUSADER 0x0059fe20
+char const* const s_chimp05_tunneler_bik_0059fe20 = "chimp05_tunneler.bik";
+
+// STRING: STRONGHOLDCRUSADER 0x0059fe38
+char const* const s_chimp04_fletcher_bik_0059fe38 = "chimp04_fletcher.bik";
+
+// STRING: STRONGHOLDCRUSADER 0x0059fe50
+char const* const s_chimp03_woodcutter_bik_0059fe50 = "chimp03_woodcutter.bik";
+
+// STRING: STRONGHOLDCRUSADER 0x0059fe68
+char const* const s_chimp02_burning_man_bik_0059fe68 = "chimp02_burning_man.bik";
+
+// STRING: STRONGHOLDCRUSADER 0x0059fe80
+char const* const s_chimp01_peasant_bik_0059fe80 = "chimp01_peasant.bik";
+
+// STRING: STRONGHOLDCRUSADER 0x0059fe94
+char const* const s_chimp66_fireeater_hlp_0059fe94 = "chimp66_fireeater.hlp";
+
+// STRING: STRONGHOLDCRUSADER 0x0059feac
+char const* const s_chimp65_juggler_hlp_0059feac = "chimp65_juggler.hlp";
+
+// STRING: STRONGHOLDCRUSADER 0x0059fec0
+char const* const s_chimp64_child_hlp_0059fec0 = "chimp64_child.hlp";
+
+// STRING: STRONGHOLDCRUSADER 0x0059fed4
+char const* const s_chimp63_mother_hlp_0059fed4 = "chimp63_mother.hlp";
+
+// STRING: STRONGHOLDCRUSADER 0x0059fee8
+char const* const s_chimp62_chicken_hlp_0059fee8 = "chimp62_chicken.hlp";
+
+// STRING: STRONGHOLDCRUSADER 0x0059fefc
+char const* const s_chimp61_ballista_hlp_0059fefc = "chimp61_ballista.hlp";
+
+// STRING: STRONGHOLDCRUSADER 0x0059ff14
+char const* const s_chimp60_portable_shield_hlp_0059ff14 = "chimp60_portable_shield.hlp";
+
+// STRING: STRONGHOLDCRUSADER 0x0059ff30
+char const* const s_chimp59_battering_ram_hlp_0059ff30 = "chimp59_battering_ram.hlp";
+
+// STRING: STRONGHOLDCRUSADER 0x0059ff4c
+char const* const s_chimp58_siege_tower_hlp_0059ff4c = "chimp58_siege_tower.hlp";
+
+// STRING: STRONGHOLDCRUSADER 0x0059ff64
+char const* const s_chimp57_jester_hlp_0059ff64 = "chimp57_jester.hlp";
+
+// STRING: STRONGHOLDCRUSADER 0x0059ff78
+char const* const s_chimp56_lady_hlp_0059ff78 = "chimp56_lady.hlp";
+
+// STRING: STRONGHOLDCRUSADER 0x0059ff8c
+char const* const s_chimp55_lord_hlp_0059ff8c = "chimp55_lord.hlp";
+
+// STRING: STRONGHOLDCRUSADER 0x0059ffa0
+char const* const s_chimp52_dog_hlp_0059ffa0 = "chimp52_dog.hlp";
+
+// STRING: STRONGHOLDCRUSADER 0x0059ffb0
+char const* const s_chimp51_cow_hlp_0059ffb0 = "chimp51_cow.hlp";
+
+// STRING: STRONGHOLDCRUSADER 0x0059ffc0
+char const* const s_chimp50_siege_tent_hlp_0059ffc0 = "chimp50_siege_tent.hlp";
+
+// STRING: STRONGHOLDCRUSADER 0x0059ffd8
+char const* const s_chimp49_seagull_hlp_0059ffd8 = "chimp49_seagull.hlp";
+
+// STRING: STRONGHOLDCRUSADER 0x0059ffec
+char const* const s_chimp48_crow_hlp_0059ffec = "chimp48_crow.hlp";
+
+// STRING: STRONGHOLDCRUSADER 0x005a0000
+char const* const s_chimp47_bear_hlp_005a0000 = "chimp47_bear.hlp";
+
+// STRING: STRONGHOLDCRUSADER 0x005a0014
+char const* const s_chimp46_rabbit_hlp_005a0014 = "chimp46_rabbit.hlp";
+
+// STRING: STRONGHOLDCRUSADER 0x005a0028
+char const* const s_chimp45_wolf_hlp_005a0028 = "chimp45_wolf.hlp";
+
+// STRING: STRONGHOLDCRUSADER 0x005a003c
+char const* const s_chimp44_deer_hlp_005a003c = "chimp44_deer.hlp";
+
+// STRING: STRONGHOLDCRUSADER 0x005a0050
+char const* const s_chimp43_trader_horse_hlp_005a0050 = "chimp43_trader_horse.hlp";
+
+// STRING: STRONGHOLDCRUSADER 0x005a006c
+char const* const s_chimp42_trader_hlp_005a006c = "chimp42_trader.hlp";
+
+// STRING: STRONGHOLDCRUSADER 0x005a0080
+char const* const s_chimp41_mangonel_hlp_005a0080 = "chimp41_mangonel.hlp";
+
+// STRING: STRONGHOLDCRUSADER 0x005a0098
+char const* const s_chimp40_trebuchet_hlp_005a0098 = "chimp40_trebuchet.hlp";
+
+// STRING: STRONGHOLDCRUSADER 0x005a00b0
+char const* const s_chimp39_catapult_hlp_005a00b0 = "chimp39_catapult.hlp";
+
+// STRING: STRONGHOLDCRUSADER 0x005a00c8
+char const* const s_chimp37_monk_hlp_005a00c8 = "chimp37_monk.hlp";
+
+// STRING: STRONGHOLDCRUSADER 0x005a00dc
+char const* const s_chimp36_innkeeper_hlp_005a00dc = "chimp36_innkeeper.hlp";
+
+// STRING: STRONGHOLDCRUSADER 0x005a00f4
+char const* const s_chimp35_drunkard_hlp_005a00f4 = "chimp35_drunkard.hlp";
+
+// STRING: STRONGHOLDCRUSADER 0x005a010c
+char const* const s_chimp34_healer_hlp_005a010c = "chimp34_healer.hlp";
+
+// STRING: STRONGHOLDCRUSADER 0x005a0120
+char const* const s_chimp33_preist_hlp_005a0120 = "chimp33_preist.hlp";
+
+// STRING: STRONGHOLDCRUSADER 0x005a0134
+char const* const s_chimp32_miner2_hlp_005a0134 = "chimp32_miner2.hlp";
+
+// STRING: STRONGHOLDCRUSADER 0x005a0148
+char const* const s_chimp31_miner1_hlp_005a0148 = "chimp31_miner1.hlp";
+
+// STRING: STRONGHOLDCRUSADER 0x005a015c
+char const* const s_chimp30_engineer_hlp_005a015c = "chimp30_engineer.hlp";
+
+// STRING: STRONGHOLDCRUSADER 0x005a0174
+char const* const s_chimp29_ladderman_hlp_005a0174 = "chimp29_ladderman.hlp";
+
+// STRING: STRONGHOLDCRUSADER 0x005a018c
+char const* const s_chimp28_knight_hlp_005a018c = "chimp28_knight.hlp";
+
+// STRING: STRONGHOLDCRUSADER 0x005a01a0
+char const* const s_chimp27_swordsman_hlp_005a01a0 = "chimp27_swordsman.hlp";
+
+// STRING: STRONGHOLDCRUSADER 0x005a01b8
+char const* const s_chimp26_maceman_hlp_005a01b8 = "chimp26_maceman.hlp";
+
+// STRING: STRONGHOLDCRUSADER 0x005a01cc
+char const* const s_chimp25_pikeman_hlp_005a01cc = "chimp25_pikeman.hlp";
+
+// STRING: STRONGHOLDCRUSADER 0x005a01e0
+char const* const s_chimp24_spearman_hlp_005a01e0 = "chimp24_spearman.hlp";
+
+// STRING: STRONGHOLDCRUSADER 0x005a01f8
+char const* const s_chimp23_xbowman_hlp_005a01f8 = "chimp23_xbowman.hlp";
+
+// STRING: STRONGHOLDCRUSADER 0x005a020c
+char const* const s_chimp22_archer_hlp_005a020c = "chimp22_archer.hlp";
+
+// STRING: STRONGHOLDCRUSADER 0x005a0220
+char const* const s_chimp21_tanner_hlp_005a0220 = "chimp21_tanner.hlp";
+
+// STRING: STRONGHOLDCRUSADER 0x005a0234
+char const* const s_chimp20_armourer_hlp_005a0234 = "chimp20_armourer.hlp";
+
+// STRING: STRONGHOLDCRUSADER 0x005a024c
+char const* const s_chimp19_blacksmith_hlp_005a024c = "chimp19_blacksmith.hlp";
+
+// STRING: STRONGHOLDCRUSADER 0x005a0264
+char const* const s_chimp18_poleturner_hlp_005a0264 = "chimp18_poleturner.hlp";
+
+// STRING: STRONGHOLDCRUSADER 0x005a027c
+char const* const s_chimp17_brewer_hlp_005a027c = "chimp17_brewer.hlp";
+
+// STRING: STRONGHOLDCRUSADER 0x005a0290
+char const* const s_chimp16_baker_hlp_005a0290 = "chimp16_baker.hlp";
+
+// STRING: STRONGHOLDCRUSADER 0x005a02a4
+char const* const s_chimp15_miller_hlp_005a02a4 = "chimp15_miller.hlp";
+
+// STRING: STRONGHOLDCRUSADER 0x005a02b8
+char const* const s_chimp14_farmer_cattle_hlp_005a02b8 = "chimp14_farmer_cattle.hlp";
+
+// STRING: STRONGHOLDCRUSADER 0x005a02d4
+char const* const s_chimp13_farmer_apples_hlp_005a02d4 = "chimp13_farmer_apples.hlp";
+
+// STRING: STRONGHOLDCRUSADER 0x005a02f0
+char const* const s_chimp12_farmer_hops_hlp_005a02f0 = "chimp12_farmer_hops.hlp";
+
+// STRING: STRONGHOLDCRUSADER 0x005a0308
+char const* const s_chimp11_farmer_wheat_hlp_005a0308 = "chimp11_farmer_wheat.hlp";
+
+// STRING: STRONGHOLDCRUSADER 0x005a0324
+char const* const s_chimp10_pitchman_hlp_005a0324 = "chimp10_pitchman.hlp";
+
+// STRING: STRONGHOLDCRUSADER 0x005a033c
+char const* const s_chimp09_quarry_ox_hlp_005a033c = "chimp09_quarry_ox.hlp";
+
+// STRING: STRONGHOLDCRUSADER 0x005a0354
+char const* const s_chimp08_quarry_grunt_hlp_005a0354 = "chimp08_quarry_grunt.hlp";
+
+// STRING: STRONGHOLDCRUSADER 0x005a0370
+char const* const s_chimp07_quarry_mason_hlp_005a0370 = "chimp07_quarry_mason.hlp";
+
+// STRING: STRONGHOLDCRUSADER 0x005a038c
+char const* const s_chimp06_hunter_hlp_005a038c = "chimp06_hunter.hlp";
+
+// STRING: STRONGHOLDCRUSADER 0x005a03a0
+char const* const s_chimp05_tunneler_hlp_005a03a0 = "chimp05_tunneler.hlp";
+
+// STRING: STRONGHOLDCRUSADER 0x005a03b8
+char const* const s_chimp04_fletcher_hlp_005a03b8 = "chimp04_fletcher.hlp";
+
+// STRING: STRONGHOLDCRUSADER 0x005a03d0
+char const* const s_chimp03_woodcutter_hlp_005a03d0 = "chimp03_woodcutter.hlp";
+
+// STRING: STRONGHOLDCRUSADER 0x005a03e8
+char const* const s_chimp02_burning_man_hlp_005a03e8 = "chimp02_burning_man.hlp";
+
+// STRING: STRONGHOLDCRUSADER 0x005a0400
+char const* const s_chimp01_peasant_hlp_005a0400 = "chimp01_peasant.hlp";
+
+// STRING: STRONGHOLDCRUSADER 0x005a0414
+char const* const s_mother_sketch_tgx_005a0414 = "mother_sketch.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005a0428
+char const* const s_chicken_sketch_tgx_005a0428 = "chicken_sketch.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005a043c
+char const* const s_jester_sketch_tgx_005a043c = "jester_sketch.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005a0450
+char const* const s_ghost_sketch_tgx_005a0450 = "ghost_sketch.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005a0464
+char const* const s_firewatch_sketch_tgx_005a0464 = "firewatch_sketch.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005a047c
+char const* const s_innkeeper_sketch_tgx_005a047c = "innkeeper_sketch.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005a0494
+char const* const s_drunk_sketch_tgx_005a0494 = "drunk_sketch.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005a04a8
+char const* const s_healer_sketch_tgx_005a04a8 = "healer_sketch.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005a04bc
+char const* const s_priest_sketch_tgx_005a04bc = "priest_sketch.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005a04d0
+char const* const s_iron_miner_sketch_tgx_005a04d0 = "iron_miner_sketch.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005a04e8
+char const* const s_tanner_sketch_tgx_005a04e8 = "tanner_sketch.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005a04fc
+char const* const s_armourer_sketch_tgx_005a04fc = "armourer_sketch.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005a0510
+char const* const s_blacksmith_sketch_tgx_005a0510 = "blacksmith_sketch.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005a0528
+char const* const s_poleturner_sketch_tgx_005a0528 = "poleturner_sketch.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005a0540
+char const* const s_brewer_sketch_tgx_005a0540 = "brewer_sketch.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005a0554
+char const* const s_baker_sketch_tgx_005a0554 = "baker_sketch.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005a0568
+char const* const s_child_sketch_tgx_005a0568 = "child_sketch.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005a057c
+char const* const s_farmer_sketch_tgx_005a057c = "farmer_sketch.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005a0590
+char const* const s_pitchworker_sketch_tgx_005a0590 = "pitchworker_sketch.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005a05a8
+char const* const s_ox_tether_sketch_tgx_005a05a8 = "ox_tether_sketch.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005a05c0
+char const* const s_stonemason_sketch_tgx_005a05c0 = "stonemason_sketch.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005a05d8
+char const* const s_hunter_sketch_tgx_005a05d8 = "hunter_sketch.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005a05ec
+char const* const s_tunnelor_sketch_tgx_005a05ec = "tunnelor_sketch.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005a0600
+char const* const s_fletcher_sketch_tgx_005a0600 = "fletcher_sketch.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005a0614
+char const* const s_woodcutter_sketch_tgx_005a0614 = "woodcutter_sketch.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005a062c
+char const* const s_null_chimp_sketch_tgx_005a062c = "null_chimp_sketch.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005a0648
+char const* const s_chimp00_null_tgxchimp00_null_tgx_005a0648
+    = "chimp00_null.tgxchimp00_null.tgxchimp00_null.tgxchimp00_null.tgxchimp00_null.tgxchimp00_null.tgxchimp00_null."
+      "tgxchimp00_null.tgxchimp00_null.tgxchimp00_null.tgxchimp00_null.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005a06fc
+char const* const s_chimp66_fireeater_tgx_005a06fc = "chimp66_fireeater.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005a0714
+char const* const s_chimp65_juggler_tgx_005a0714 = "chimp65_juggler.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005a0728
+char const* const s_chimp64_child_tgx_005a0728 = "chimp64_child.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005a073c
+char const* const s_chimp63_mother_tgx_005a073c = "chimp63_mother.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005a0750
+char const* const s_chimp62_chicken_tgx_005a0750 = "chimp62_chicken.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005a0764
+char const* const s_chimp61_ballista_tgx_005a0764 = "chimp61_ballista.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005a077c
+char const* const s_chimp60_portable_shield_tgx_005a077c = "chimp60_portable_shield.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005a0798
+char const* const s_chimp59_battering_ram_tgx_005a0798 = "chimp59_battering_ram.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005a07b4
+char const* const s_chimp58_siege_tower_tgx_005a07b4 = "chimp58_siege_tower.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005a07cc
+char const* const s_chimp57_jester_tgx_005a07cc = "chimp57_jester.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005a07e0
+char const* const s_chimp56_lady_tgx_005a07e0 = "chimp56_lady.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005a07f4
+char const* const s_chimp55_lord_tgx_005a07f4 = "chimp55_lord.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005a0808
+char const* const s_chimp54_ghost_tgx_005a0808 = "chimp54_ghost.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005a081c
+char const* const s_chimp52_dog_tgx_005a081c = "chimp52_dog.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005a082c
+char const* const s_chimp51_cow_tgx_005a082c = "chimp51_cow.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005a083c
+char const* const s_chimp50_siege_tent_tgx_005a083c = "chimp50_siege_tent.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005a0854
+char const* const s_chimp49_seagull_tgx_005a0854 = "chimp49_seagull.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005a0868
+char const* const s_chimp48_crow_tgx_005a0868 = "chimp48_crow.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005a087c
+char const* const s_chimp47_bear_tgx_005a087c = "chimp47_bear.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005a0890
+char const* const s_chimp46_rabbit_tgx_005a0890 = "chimp46_rabbit.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005a08a4
+char const* const s_chimp45_wolf_tgx_005a08a4 = "chimp45_wolf.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005a08b8
+char const* const s_chimp44_deer_tgx_005a08b8 = "chimp44_deer.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005a08cc
+char const* const s_chimp43_trader_horse_tgx_005a08cc = "chimp43_trader_horse.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005a08e8
+char const* const s_chimp42_trader_tgx_005a08e8 = "chimp42_trader.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005a08fc
+char const* const s_chimp41_mangonel_tgx_005a08fc = "chimp41_mangonel.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005a0914
+char const* const s_chimp40_trebuchet_tgx_005a0914 = "chimp40_trebuchet.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005a092c
+char const* const s_chimp39_catapult_tgx_005a092c = "chimp39_catapult.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005a0944
+char const* const s_chimp37_monk_tgx_005a0944 = "chimp37_monk.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005a0958
+char const* const s_chimp36_innkeeper_tgx_005a0958 = "chimp36_innkeeper.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005a0970
+char const* const s_chimp35_drunkard_tgx_005a0970 = "chimp35_drunkard.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005a0988
+char const* const s_chimp34_healer_tgx_005a0988 = "chimp34_healer.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005a099c
+char const* const s_chimp33_preist_tgx_005a099c = "chimp33_preist.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005a09b0
+char const* const s_chimp32_miner2_tgx_005a09b0 = "chimp32_miner2.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005a09c4
+char const* const s_chimp31_miner1_tgx_005a09c4 = "chimp31_miner1.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005a09d8
+char const* const s_chimp30_engineer_tgx_005a09d8 = "chimp30_engineer.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005a09f0
+char const* const s_chimp29_ladderman_tgx_005a09f0 = "chimp29_ladderman.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005a0a08
+char const* const s_chimp28_knight_tgx_005a0a08 = "chimp28_knight.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005a0a1c
+char const* const s_chimp27_swordsman_tgx_005a0a1c = "chimp27_swordsman.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005a0a34
+char const* const s_chimp26_maceman_tgx_005a0a34 = "chimp26_maceman.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005a0a48
+char const* const s_chimp25_pikeman_tgx_005a0a48 = "chimp25_pikeman.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005a0a5c
+char const* const s_chimp24_spearman_tgx_005a0a5c = "chimp24_spearman.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005a0a74
+char const* const s_chimp23_xbowman_tgx_005a0a74 = "chimp23_xbowman.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005a0a88
+char const* const s_chimp22_archer_tgx_005a0a88 = "chimp22_archer.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005a0a9c
+char const* const s_chimp21_tanner_tgx_005a0a9c = "chimp21_tanner.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005a0ab0
+char const* const s_chimp20_armourer_tgx_005a0ab0 = "chimp20_armourer.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005a0ac8
+char const* const s_chimp19_blacksmith_tgx_005a0ac8 = "chimp19_blacksmith.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005a0ae0
+char const* const s_chimp18_poleturner_tgx_005a0ae0 = "chimp18_poleturner.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005a0af8
+char const* const s_chimp17_brewer_tgx_005a0af8 = "chimp17_brewer.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005a0b0c
+char const* const s_chimp16_baker_tgx_005a0b0c = "chimp16_baker.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005a0b20
+char const* const s_chimp15_miller_tgx_005a0b20 = "chimp15_miller.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005a0b34
+char const* const s_chimp14_farmer_cattle_tgx_005a0b34 = "chimp14_farmer_cattle.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005a0b50
+char const* const s_chimp13_farmer_apples_tgx_005a0b50 = "chimp13_farmer_apples.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005a0b6c
+char const* const s_chimp12_farmer_hops_tgx_005a0b6c = "chimp12_farmer_hops.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005a0b84
+char const* const s_chimp11_farmer_wheat_tgx_005a0b84 = "chimp11_farmer_wheat.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005a0ba0
+char const* const s_chimp10_pitchman_tgx_005a0ba0 = "chimp10_pitchman.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005a0bb8
+char const* const s_chimp09_quarry_ox_tgx_005a0bb8 = "chimp09_quarry_ox.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005a0bd0
+char const* const s_chimp08_quarry_grunt_tgx_005a0bd0 = "chimp08_quarry_grunt.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005a0bec
+char const* const s_chimp07_quarry_mason_tgx_005a0bec = "chimp07_quarry_mason.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005a0c08
+char const* const s_chimp06_hunter_tgx_005a0c08 = "chimp06_hunter.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005a0c1c
+char const* const s_chimp05_tunneler_tgx_005a0c1c = "chimp05_tunneler.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005a0c34
+char const* const s_chimp04_fletcher_tgx_005a0c34 = "chimp04_fletcher.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005a0c4c
+char const* const s_chimp03_woodcutter_tgx_005a0c4c = "chimp03_woodcutter.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005a0c64
+char const* const s_chimp02_burning_man_tgx_005a0c64 = "chimp02_burning_man.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005a0c7c
+char const* const s_chimp01_peasant_tgx_005a0c7c = "chimp01_peasant.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005a0c90
+char const* const s_chimp00_null_tgx_005a0c90 = "chimp00_null.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005a0ca4
+char const* const s_UC_BLD_OUTPOST_ARAB_005a0ca4 = "UC_BLD_OUTPOST_ARAB";
+
+// STRING: STRONGHOLDCRUSADER 0x005a0cb8
+char const* const s_UC_BLD_OUTPOST_005a0cb8 = "UC_BLD_OUTPOST";
+
+// STRING: STRONGHOLDCRUSADER 0x005a0cc8
+char const* const s_UC_BLD_ARAB_BALLISTA_005a0cc8 = "UC_BLD_ARAB_BALLISTA";
+
+// STRING: STRONGHOLDCRUSADER 0x005a0ce0
+char const* const s_UC_BLD_WATERPOT_005a0ce0 = "UC_BLD_WATERPOT";
+
+// STRING: STRONGHOLDCRUSADER 0x005a0cf0
+char const* const s_UC_PLP_ARAB_BALLISTA_005a0cf0 = "UC_PLP_ARAB_BALLISTA";
+
+// STRING: STRONGHOLDCRUSADER 0x005a0d08
+char const* const s_UC_PLP_ARAB_GRENADIER_005a0d08 = "UC_PLP_ARAB_GRENADIER";
+
+// STRING: STRONGHOLDCRUSADER 0x005a0d20
+char const* const s_UC_PLP_ARAB_SWORDSMEN_005a0d20 = "UC_PLP_ARAB_SWORDSMEN";
+
+// STRING: STRONGHOLDCRUSADER 0x005a0d38
+char const* const s_UC_PLP_ARAB_HORSEMAN_005a0d38 = "UC_PLP_ARAB_HORSEMAN";
+
+// STRING: STRONGHOLDCRUSADER 0x005a0d50
+char const* const s_UC_PLP_ARAB_ASSASIN_005a0d50 = "UC_PLP_ARAB_ASSASIN";
+
+// STRING: STRONGHOLDCRUSADER 0x005a0d64
+char const* const s_UC_PLP_ARAB_SLINGER_005a0d64 = "UC_PLP_ARAB_SLINGER";
+
+// STRING: STRONGHOLDCRUSADER 0x005a0d78
+char const* const s_UC_PLP_ARAB_SLAVE_005a0d78 = "UC_PLP_ARAB_SLAVE";
+
+// STRING: STRONGHOLDCRUSADER 0x005a0d8c
+char const* const s_UC_PLP_ARAB_ARCHER_005a0d8c = "UC_PLP_ARAB_ARCHER";
+
+// STRING: STRONGHOLDCRUSADER 0x005a0da0
+char const* const s_UC_HEADS_ON_SPIKES_005a0da0 = "UC_HEADS_ON_SPIKES";
+
+// STRING: STRONGHOLDCRUSADER 0x005a0db4
+char const* const s_UC_POND_LARGE_005a0db4 = "UC_POND_LARGE";
+
+// STRING: STRONGHOLDCRUSADER 0x005a0dc4
+char const* const s_UC_BEAR_CAVE_005a0dc4 = "UC_BEAR_CAVE";
+
+// STRING: STRONGHOLDCRUSADER 0x005a0dd4
+char const* const s_UC_POND_005a0dd4 = "UC_POND";
+
+// STRING: STRONGHOLDCRUSADER 0x005a0ddc
+char const* const s_UC_DANCING_BEAR_005a0ddc = "UC_DANCING_BEAR";
+
+// STRING: STRONGHOLDCRUSADER 0x005a0dec
+char const* const s_UC_BEE_HIVE_005a0dec = "UC_BEE_HIVE";
+
+// STRING: STRONGHOLDCRUSADER 0x005a0df8
+char const* const s_UC_SHRINE_005a0df8 = "UC_SHRINE";
+
+// STRING: STRONGHOLDCRUSADER 0x005a0e04
+char const* const s_UC_STATUE_005a0e04 = "UC_STATUE";
+
+// STRING: STRONGHOLDCRUSADER 0x005a0e10
+char const* const s_UC_DOG_CAGE_005a0e10 = "UC_DOG_CAGE";
+
+// STRING: STRONGHOLDCRUSADER 0x005a0e1c
+char const* const s_UC_DUNKING_STOOL_005a0e1c = "UC_DUNKING_STOOL";
+
+// STRING: STRONGHOLDCRUSADER 0x005a0e30
+char const* const s_UC_CHOPPING_BLOCK_005a0e30 = "UC_CHOPPING_BLOCK";
+
+// STRING: STRONGHOLDCRUSADER 0x005a0e44
+char const* const s_UC_RACK_FLOGGING_005a0e44 = "UC_RACK_FLOGGING";
+
+// STRING: STRONGHOLDCRUSADER 0x005a0e58
+char const* const s_UC_RACK_STRETCHING_005a0e58 = "UC_RACK_STRETCHING";
+
+// STRING: STRONGHOLDCRUSADER 0x005a0e6c
+char const* const s_UC_DUNGEON_005a0e6c = "UC_DUNGEON";
+
+// STRING: STRONGHOLDCRUSADER 0x005a0e78
+char const* const s_UC_GIBBET_005a0e78 = "UC_GIBBET";
+
+// STRING: STRONGHOLDCRUSADER 0x005a0e84
+char const* const s_UC_BURNING_STAKE_005a0e84 = "UC_BURNING_STAKE";
+
+// STRING: STRONGHOLDCRUSADER 0x005a0e98
+char const* const s_UC_CESS_PIT_005a0e98 = "UC_CESS_PIT";
+
+// STRING: STRONGHOLDCRUSADER 0x005a0ea4
+char const* const s_UC_BACK_005a0ea4 = "UC_BACK";
+
+// STRING: STRONGHOLDCRUSADER 0x005a0eac
+char const* const s_UC_BUILD_005a0eac = "UC_BUILD";
+
+// STRING: STRONGHOLDCRUSADER 0x005a0eb8
+char const* const s_UC_STOP_005a0eb8 = "UC_STOP";
+
+// STRING: STRONGHOLDCRUSADER 0x005a0ec0
+char const* const s_UC_STANCE_AGGRESSIVE_005a0ec0 = "UC_STANCE_AGGRESSIVE";
+
+// STRING: STRONGHOLDCRUSADER 0x005a0ed8
+char const* const s_UC_STANCE_DEFENSIVE_005a0ed8 = "UC_STANCE_DEFENSIVE";
+
+// STRING: STRONGHOLDCRUSADER 0x005a0eec
+char const* const s_UC_STANCE_STAND_005a0eec = "UC_STANCE_STAND";
+
+// STRING: STRONGHOLDCRUSADER 0x005a0efc
+char const* const s_UC_TTS_TUNNELERS_005a0efc = "UC_TTS_TUNNELERS";
+
+// STRING: STRONGHOLDCRUSADER 0x005a0f10
+char const* const s_UC_PLP_TUNNELERS_005a0f10 = "UC_PLP_TUNNELERS";
+
+// STRING: STRONGHOLDCRUSADER 0x005a0f24
+char const* const s_UC_PLP_PORTABLE_SHIELDS_005a0f24 = "UC_PLP_PORTABLE_SHIELDS";
+
+// STRING: STRONGHOLDCRUSADER 0x005a0f3c
+char const* const s_UC_PLP_SIEGE_TOWERS_005a0f3c = "UC_PLP_SIEGE_TOWERS";
+
+// STRING: STRONGHOLDCRUSADER 0x005a0f50
+char const* const s_UC_PLP_BATTERING_RAM_005a0f50 = "UC_PLP_BATTERING_RAM";
+
+// STRING: STRONGHOLDCRUSADER 0x005a0f68
+char const* const s_UC_PLP_TREBUCHETS_005a0f68 = "UC_PLP_TREBUCHETS";
+
+// STRING: STRONGHOLDCRUSADER 0x005a0f7c
+char const* const s_UC_PLP_CATAPULTS_005a0f7c = "UC_PLP_CATAPULTS";
+
+// STRING: STRONGHOLDCRUSADER 0x005a0f90
+char const* const s_UC_PLP_MONKS_005a0f90 = "UC_PLP_MONKS";
+
+// STRING: STRONGHOLDCRUSADER 0x005a0fa0
+char const* const s_UC_PLP_ENGINEERS_POTS_005a0fa0 = "UC_PLP_ENGINEERS_POTS";
+
+// STRING: STRONGHOLDCRUSADER 0x005a0fb8
+char const* const s_UC_PLP_ENGINEERS_005a0fb8 = "UC_PLP_ENGINEERS";
+
+// STRING: STRONGHOLDCRUSADER 0x005a0fcc
+char const* const s_UC_PLP_LADDERMEN_005a0fcc = "UC_PLP_LADDERMEN";
+
+// STRING: STRONGHOLDCRUSADER 0x005a0fe0
+char const* const s_UC_PLP_KNIGHTS_005a0fe0 = "UC_PLP_KNIGHTS";
+
+// STRING: STRONGHOLDCRUSADER 0x005a0ff0
+char const* const s_UC_PLP_SWORDSMEN_005a0ff0 = "UC_PLP_SWORDSMEN";
+
+// STRING: STRONGHOLDCRUSADER 0x005a1004
+char const* const s_UC_PLP_XBOWMEN_005a1004 = "UC_PLP_XBOWMEN";
+
+// STRING: STRONGHOLDCRUSADER 0x005a1014
+char const* const s_UC_PLP_MACEMEN_005a1014 = "UC_PLP_MACEMEN";
+
+// STRING: STRONGHOLDCRUSADER 0x005a1024
+char const* const s_UC_PLP_PIKEMEN_005a1024 = "UC_PLP_PIKEMEN";
+
+// STRING: STRONGHOLDCRUSADER 0x005a1034
+char const* const s_UC_PLP_SPEARMEN_005a1034 = "UC_PLP_SPEARMEN";
+
+// STRING: STRONGHOLDCRUSADER 0x005a1044
+char const* const s_UC_PLP_ARCHERS_005a1044 = "UC_PLP_ARCHERS";
+
+// STRING: STRONGHOLDCRUSADER 0x005a1054
+char const* const s_UC_TTS_LADDERMEN_005a1054 = "UC_TTS_LADDERMEN";
+
+// STRING: STRONGHOLDCRUSADER 0x005a1068
+char const* const s_UC_TTS_MONKS_005a1068 = "UC_TTS_MONKS";
+
+// STRING: STRONGHOLDCRUSADER 0x005a1078
+char const* const s_UC_TTS_KNIGHTS_005a1078 = "UC_TTS_KNIGHTS";
+
+// STRING: STRONGHOLDCRUSADER 0x005a1088
+char const* const s_UC_TTS_XBOWMEN_005a1088 = "UC_TTS_XBOWMEN";
+
+// STRING: STRONGHOLDCRUSADER 0x005a1098
+char const* const s_UC_TTS_SWORDSMEN_005a1098 = "UC_TTS_SWORDSMEN";
+
+// STRING: STRONGHOLDCRUSADER 0x005a10ac
+char const* const s_UC_TTS_MACEMEN_005a10ac = "UC_TTS_MACEMEN";
+
+// STRING: STRONGHOLDCRUSADER 0x005a10bc
+char const* const s_UC_TTS_PIKEMEN_005a10bc = "UC_TTS_PIKEMEN";
+
+// STRING: STRONGHOLDCRUSADER 0x005a10cc
+char const* const s_UC_TTS_ENGINEERS_005a10cc = "UC_TTS_ENGINEERS";
+
+// STRING: STRONGHOLDCRUSADER 0x005a10e0
+char const* const s_UC_TTS_ARCHERS_005a10e0 = "UC_TTS_ARCHERS";
+
+// STRING: STRONGHOLDCRUSADER 0x005a10f0
+char const* const s_UC_TTS_SPEARMEN_005a10f0 = "UC_TTS_SPEARMEN";
+
+// STRING: STRONGHOLDCRUSADER 0x005a1100
+char const* const s_UC_BLD_GRANARY_KEEPS_ONLY_005a1100 = "UC_BLD_GRANARY_KEEPS_ONLY";
+
+// STRING: STRONGHOLDCRUSADER 0x005a111c
+char const* const s_UC_KEEPS_ONLY_005a111c = "UC_KEEPS_ONLY";
+
+// STRING: STRONGHOLDCRUSADER 0x005a112c
+char const* const s_UC_BLD_RUINS13_005a112c = "UC_BLD_RUINS13";
+
+// STRING: STRONGHOLDCRUSADER 0x005a113c
+char const* const s_UC_BLD_RUINS12_005a113c = "UC_BLD_RUINS12";
+
+// STRING: STRONGHOLDCRUSADER 0x005a114c
+char const* const s_UC_BLD_RUINS11_005a114c = "UC_BLD_RUINS11";
+
+// STRING: STRONGHOLDCRUSADER 0x005a115c
+char const* const s_UC_BLD_RUINS10_005a115c = "UC_BLD_RUINS10";
+
+// STRING: STRONGHOLDCRUSADER 0x005a116c
+char const* const s_UC_BLD_RUINS9_005a116c = "UC_BLD_RUINS9";
+
+// STRING: STRONGHOLDCRUSADER 0x005a117c
+char const* const s_UC_BLD_RUINS8_005a117c = "UC_BLD_RUINS8";
+
+// STRING: STRONGHOLDCRUSADER 0x005a118c
+char const* const s_UC_BLD_RUINS7_005a118c = "UC_BLD_RUINS7";
+
+// STRING: STRONGHOLDCRUSADER 0x005a119c
+char const* const s_UC_BLD_RUINS6_005a119c = "UC_BLD_RUINS6";
+
+// STRING: STRONGHOLDCRUSADER 0x005a11ac
+char const* const s_UC_BLD_RUINS5_005a11ac = "UC_BLD_RUINS5";
+
+// STRING: STRONGHOLDCRUSADER 0x005a11bc
+char const* const s_UC_BLD_RUINS4_005a11bc = "UC_BLD_RUINS4";
+
+// STRING: STRONGHOLDCRUSADER 0x005a11cc
+char const* const s_UC_BLD_RUINS3_005a11cc = "UC_BLD_RUINS3";
+
+// STRING: STRONGHOLDCRUSADER 0x005a11dc
+char const* const s_UC_BLD_RUINS2_005a11dc = "UC_BLD_RUINS2";
+
+// STRING: STRONGHOLDCRUSADER 0x005a11ec
+char const* const s_UC_BLD_RUINS1_005a11ec = "UC_BLD_RUINS1";
+
+// STRING: STRONGHOLDCRUSADER 0x005a11fc
+char const* const s_UC_MAP_KEEP8_005a11fc = "UC_MAP_KEEP8";
+
+// STRING: STRONGHOLDCRUSADER 0x005a120c
+char const* const s_UC_MAP_KEEP7_005a120c = "UC_MAP_KEEP7";
+
+// STRING: STRONGHOLDCRUSADER 0x005a121c
+char const* const s_UC_MAP_KEEP6_005a121c = "UC_MAP_KEEP6";
+
+// STRING: STRONGHOLDCRUSADER 0x005a122c
+char const* const s_UC_MAP_KEEP5_005a122c = "UC_MAP_KEEP5";
+
+// STRING: STRONGHOLDCRUSADER 0x005a123c
+char const* const s_UC_MAP_KEEP4_005a123c = "UC_MAP_KEEP4";
+
+// STRING: STRONGHOLDCRUSADER 0x005a124c
+char const* const s_UC_MAP_KEEP3_005a124c = "UC_MAP_KEEP3";
+
+// STRING: STRONGHOLDCRUSADER 0x005a125c
+char const* const s_UC_MAP_KEEP2_005a125c = "UC_MAP_KEEP2";
+
+// STRING: STRONGHOLDCRUSADER 0x005a126c
+char const* const s_UC_MAP_KEEP1_005a126c = "UC_MAP_KEEP1";
+
+// STRING: STRONGHOLDCRUSADER 0x005a127c
+char const* const s_UC_PITCH_DITCH_005a127c = "UC_PITCH_DITCH";
+
+// STRING: STRONGHOLDCRUSADER 0x005a128c
+char const* const s_UC_LAUNCHCOW_005a128c = "UC_LAUNCHCOW";
+
+// STRING: STRONGHOLDCRUSADER 0x005a129c
+char const* const s_UC_ATTACKHERE_005a129c = "UC_ATTACKHERE";
+
+// STRING: STRONGHOLDCRUSADER 0x005a12ac
+char const* const s_UC_TUNNELHERE_005a12ac = "UC_TUNNELHERE";
+
+// STRING: STRONGHOLDCRUSADER 0x005a12bc
+char const* const s_UC_DISBAND_005a12bc = "UC_DISBAND";
+
+// STRING: STRONGHOLDCRUSADER 0x005a12c8
+char const* const s_UC_PATROL_005a12c8 = "UC_PATROL";
+
+// STRING: STRONGHOLDCRUSADER 0x005a12d4
+char const* const s_UC_BLD_POUR_OIL_005a12d4 = "UC_BLD_POUR_OIL";
+
+// STRING: STRONGHOLDCRUSADER 0x005a12e4
+char const* const s_UC_BLD_BALLISTA_005a12e4 = "UC_BLD_BALLISTA";
+
+// STRING: STRONGHOLDCRUSADER 0x005a12f4
+char const* const s_UC_MAP_ESTUARY_005a12f4 = "UC_MAP_ESTUARY";
+
+// STRING: STRONGHOLDCRUSADER 0x005a1304
+char const* const s_UC_MAP_SIGNPOST_005a1304 = "UC_MAP_SIGNPOST";
+
+// STRING: STRONGHOLDCRUSADER 0x005a1314
+char const* const s_UC_MAP_BIGROCK5_005a1314 = "UC_MAP_BIGROCK5";
+
+// STRING: STRONGHOLDCRUSADER 0x005a1324
+char const* const s_UC_MAP_BIGROCK4_005a1324 = "UC_MAP_BIGROCK4";
+
+// STRING: STRONGHOLDCRUSADER 0x005a1334
+char const* const s_UC_MAP_BIGROCK3_005a1334 = "UC_MAP_BIGROCK3";
+
+// STRING: STRONGHOLDCRUSADER 0x005a1344
+char const* const s_UC_MAP_BIGROCK2_005a1344 = "UC_MAP_BIGROCK2";
+
+// STRING: STRONGHOLDCRUSADER 0x005a1354
+char const* const s_UC_MAP_BIGROCK1_005a1354 = "UC_MAP_BIGROCK1";
+
+// STRING: STRONGHOLDCRUSADER 0x005a1364
+char const* const s_UC_MAP_RIPPLE_005a1364 = "UC_MAP_RIPPLE";
+
+// STRING: STRONGHOLDCRUSADER 0x005a1374
+char const* const s_UC_MAP_FOAM_005a1374 = "UC_MAP_FOAM";
+
+// STRING: STRONGHOLDCRUSADER 0x005a1380
+char const* const s_UC_MAP_FORD_005a1380 = "UC_MAP_FORD";
+
+// STRING: STRONGHOLDCRUSADER 0x005a138c
+char const* const s_UC_MAP_RIVER_005a138c = "UC_MAP_RIVER";
+
+// STRING: STRONGHOLDCRUSADER 0x005a139c
+char const* const s_UC_MAP_OIL_005a139c = "UC_MAP_OIL";
+
+// STRING: STRONGHOLDCRUSADER 0x005a13a8
+char const* const s_UC_MAP_MARSH_005a13a8 = "UC_MAP_MARSH";
+
+// STRING: STRONGHOLDCRUSADER 0x005a13b8
+char const* const s_UC_MAP_BEACH_005a13b8 = "UC_MAP_BEACH";
+
+// STRING: STRONGHOLDCRUSADER 0x005a13c8
+char const* const s_UC_MAP_SHALLOW_005a13c8 = "UC_MAP_SHALLOW";
+
+// STRING: STRONGHOLDCRUSADER 0x005a13d8
+char const* const s_UC_MAP_SEA_005a13d8 = "UC_MAP_SEA";
+
+// STRING: STRONGHOLDCRUSADER 0x005a13e4
+char const* const s_UC_MAP_CROW_005a13e4 = "UC_MAP_CROW";
+
+// STRING: STRONGHOLDCRUSADER 0x005a13f0
+char const* const s_UC_MAP_SEAGULL_005a13f0 = "UC_MAP_SEAGULL";
+
+// STRING: STRONGHOLDCRUSADER 0x005a1400
+char const* const s_UC_MAP_BEAR_005a1400 = "UC_MAP_BEAR";
+
+// STRING: STRONGHOLDCRUSADER 0x005a140c
+char const* const s_UC_MAP_RABBIT_005a140c = "UC_MAP_RABBIT";
+
+// STRING: STRONGHOLDCRUSADER 0x005a141c
+char const* const s_UC_MAP_WOLF_005a141c = "UC_MAP_WOLF";
+
+// STRING: STRONGHOLDCRUSADER 0x005a1428
+char const* const s_UC_MAP_DEER_005a1428 = "UC_MAP_DEER";
+
+// STRING: STRONGHOLDCRUSADER 0x005a1434
+char const* const s_UC_MAP_SHRUB2_005a1434 = "UC_MAP_SHRUB2";
+
+// STRING: STRONGHOLDCRUSADER 0x005a1444
+char const* const s_UC_MAP_SHRUB1E_005a1444 = "UC_MAP_SHRUB1E";
+
+// STRING: STRONGHOLDCRUSADER 0x005a1454
+char const* const s_UC_MAP_SHRUB1D_005a1454 = "UC_MAP_SHRUB1D";
+
+// STRING: STRONGHOLDCRUSADER 0x005a1464
+char const* const s_UC_MAP_SHRUB1C_005a1464 = "UC_MAP_SHRUB1C";
+
+// STRING: STRONGHOLDCRUSADER 0x005a1474
+char const* const s_UC_MAP_SHRUB1B_005a1474 = "UC_MAP_SHRUB1B";
+
+// STRING: STRONGHOLDCRUSADER 0x005a1484
+char const* const s_UC_MAP_SHRUB1A_005a1484 = "UC_MAP_SHRUB1A";
+
+// STRING: STRONGHOLDCRUSADER 0x005a1494
+char const* const s_UC_MAP_BIRCH_005a1494 = "UC_MAP_BIRCH";
+
+// STRING: STRONGHOLDCRUSADER 0x005a14a4
+char const* const s_UC_MAP_PINE_005a14a4 = "UC_MAP_PINE";
+
+// STRING: STRONGHOLDCRUSADER 0x005a14b0
+char const* const s_UC_MAP_OAK_005a14b0 = "UC_MAP_OAK";
+
+// STRING: STRONGHOLDCRUSADER 0x005a14bc
+char const* const s_UC_MAP_CHESTNUT_005a14bc = "UC_MAP_CHESTNUT";
+
+// STRING: STRONGHOLDCRUSADER 0x005a14cc
+char const* const s_UC_MAP_STONES_005a14cc = "UC_MAP_STONES";
+
+// STRING: STRONGHOLDCRUSADER 0x005a14dc
+char const* const s_UC_MAP_DIRT_005a14dc = "UC_MAP_DIRT";
+
+// STRING: STRONGHOLDCRUSADER 0x005a14e8
+char const* const s_UC_MAP_IRON_005a14e8 = "UC_MAP_IRON";
+
+// STRING: STRONGHOLDCRUSADER 0x005a14f4
+char const* const s_UC_MAP_BOULDERS_005a14f4 = "UC_MAP_BOULDERS";
+
+// STRING: STRONGHOLDCRUSADER 0x005a1504
+char const* const s_UC_MAP_PEBBLES_005a1504 = "UC_MAP_PEBBLES";
+
+// STRING: STRONGHOLDCRUSADER 0x005a1514
+char const* const s_UC_MAP_ROCKS_005a1514 = "UC_MAP_ROCKS";
+
+// STRING: STRONGHOLDCRUSADER 0x005a1524
+char const* const s_UC_MAP_GRASS_005a1524 = "UC_MAP_GRASS";
+
+// STRING: STRONGHOLDCRUSADER 0x005a1534
+char const* const s_UC_MAP_LAND_005a1534 = "UC_MAP_LAND";
+
+// STRING: STRONGHOLDCRUSADER 0x005a1540
+char const* const s_UC_MAP_HI_PLAIN_005a1540 = "UC_MAP_HI_PLAIN";
+
+// STRING: STRONGHOLDCRUSADER 0x005a1550
+char const* const s_UC_MAP_MID_PLAIN_005a1550 = "UC_MAP_MID_PLAIN";
+
+// STRING: STRONGHOLDCRUSADER 0x005a1564
+char const* const s_UC_MAP_HILL_005a1564 = "UC_MAP_HILL";
+
+// STRING: STRONGHOLDCRUSADER 0x005a1570
+char const* const s_UC_MAP_MOUNTAIN_005a1570 = "UC_MAP_MOUNTAIN";
+
+// STRING: STRONGHOLDCRUSADER 0x005a1580
+char const* const s_UC_MAP_EQUALIZE_005a1580 = "UC_MAP_EQUALIZE";
+
+// STRING: STRONGHOLDCRUSADER 0x005a1590
+char const* const s_UC_MAP_MAX_005a1590 = "UC_MAP_MAX";
+
+// STRING: STRONGHOLDCRUSADER 0x005a159c
+char const* const s_UC_MAP_MIN_005a159c = "UC_MAP_MIN";
+
+// STRING: STRONGHOLDCRUSADER 0x005a15a8
+char const* const s_UC_MAP_LOWER_005a15a8 = "UC_MAP_LOWER";
+
+// STRING: STRONGHOLDCRUSADER 0x005a15b8
+char const* const s_UC_MAP_RAISE_005a15b8 = "UC_MAP_RAISE";
+
+// STRING: STRONGHOLDCRUSADER 0x005a15c8
+char const* const s_UC_MAP_DELETE_005a15c8 = "UC_MAP_DELETE";
+
+// STRING: STRONGHOLDCRUSADER 0x005a15d8
+char const* const s_UC_MAP_SNAP_005a15d8 = "UC_MAP_SNAP";
+
+// STRING: STRONGHOLDCRUSADER 0x005a15e4
+char const* const s_UC_MAP_BRUSH_005a15e4 = "UC_MAP_BRUSH";
+
+// STRING: STRONGHOLDCRUSADER 0x005a15f4
+char const* const s_UC_MAP_GAME_005a15f4 = "UC_MAP_GAME";
+
+// STRING: STRONGHOLDCRUSADER 0x005a1600
+char const* const s_UC_MAP_FEATURE_005a1600 = "UC_MAP_FEATURE";
+
+// STRING: STRONGHOLDCRUSADER 0x005a1610
+char const* const s_UC_MAP_WATER_005a1610 = "UC_MAP_WATER";
+
+// STRING: STRONGHOLDCRUSADER 0x005a1620
+char const* const s_UC_MAP_ANIMAL_005a1620 = "UC_MAP_ANIMAL";
+
+// STRING: STRONGHOLDCRUSADER 0x005a1630
+char const* const s_UC_MAP_OBJ_005a1630 = "UC_MAP_OBJ";
+
+// STRING: STRONGHOLDCRUSADER 0x005a163c
+char const* const s_UC_MAP_LANDTYPE_005a163c = "UC_MAP_LANDTYPE";
+
+// STRING: STRONGHOLDCRUSADER 0x005a164c
+char const* const s_UC_MAP_HEIGHT_005a164c = "UC_MAP_HEIGHT";
+
+// STRING: STRONGHOLDCRUSADER 0x005a165c
+char const* const s_UC_GATE2_EAST_005a165c = "UC_GATE2_EAST";
+
+// STRING: STRONGHOLDCRUSADER 0x005a166c
+char const* const s_UC_GATE2_NORTH_005a166c = "UC_GATE2_NORTH";
+
+// STRING: STRONGHOLDCRUSADER 0x005a167c
+char const* const s_UC_GATE1_EAST_005a167c = "UC_GATE1_EAST";
+
+// STRING: STRONGHOLDCRUSADER 0x005a168c
+char const* const s_UC_GATE1_NORTH_005a168c = "UC_GATE1_NORTH";
+
+// STRING: STRONGHOLDCRUSADER 0x005a169c
+char const* const s_UC_WOODGATE_WEST_005a169c = "UC_WOODGATE_WEST";
+
+// STRING: STRONGHOLDCRUSADER 0x005a16b0
+char const* const s_UC_WOODGATE_SOUTH_005a16b0 = "UC_WOODGATE_SOUTH";
+
+// STRING: STRONGHOLDCRUSADER 0x005a16c4
+char const* const s_UC_WOODGATE_EAST_005a16c4 = "UC_WOODGATE_EAST";
+
+// STRING: STRONGHOLDCRUSADER 0x005a16d8
+char const* const s_UC_WOODGATE_NORTH_005a16d8 = "UC_WOODGATE_NORTH";
+
+// STRING: STRONGHOLDCRUSADER 0x005a16ec
+char const* const s_UC_GATEDIRC3_005a16ec = "UC_GATEDIRC3";
+
+// STRING: STRONGHOLDCRUSADER 0x005a16fc
+char const* const s_UC_GATEDIRC2_005a16fc = "UC_GATEDIRC2";
+
+// STRING: STRONGHOLDCRUSADER 0x005a170c
+char const* const s_UC_GATEDIRC1_005a170c = "UC_GATEDIRC1";
+
+// STRING: STRONGHOLDCRUSADER 0x005a171c
+char const* const s_UC_BLD_OIL_SMELTER_005a171c = "UC_BLD_OIL_SMELTER";
+
+// STRING: STRONGHOLDCRUSADER 0x005a1730
+char const* const s_UC_BLD_PORTABLE_SHIELD_005a1730 = "UC_BLD_PORTABLE_SHIELD";
+
+// STRING: STRONGHOLDCRUSADER 0x005a1748
+char const* const s_UC_BLD_BATTERING_RAM_005a1748 = "UC_BLD_BATTERING_RAM";
+
+// STRING: STRONGHOLDCRUSADER 0x005a1760
+char const* const s_UC_BLD_SIEGE_TOWER_005a1760 = "UC_BLD_SIEGE_TOWER";
+
+// STRING: STRONGHOLDCRUSADER 0x005a1774
+char const* const s_UC_BLD_TREBUCHET_005a1774 = "UC_BLD_TREBUCHET";
+
+// STRING: STRONGHOLDCRUSADER 0x005a1788
+char const* const s_UC_BLD_CATAPULT_005a1788 = "UC_BLD_CATAPULT";
+
+// STRING: STRONGHOLDCRUSADER 0x005a1798
+char const* const s_UC_BLD_MANGONEL_005a1798 = "UC_BLD_MANGONEL";
+
+// STRING: STRONGHOLDCRUSADER 0x005a17a8
+char const* const s_UC_SUB_GARDENS_005a17a8 = "UC_SUB_GARDENS";
+
+// STRING: STRONGHOLDCRUSADER 0x005a17b8
+char const* const s_UC_DIG_MOATS_005a17b8 = "UC_DIG_MOATS";
+
+// STRING: STRONGHOLDCRUSADER 0x005a17c8
+char const* const s_UC_SUB_MOATS_005a17c8 = "UC_SUB_MOATS";
+
+// STRING: STRONGHOLDCRUSADER 0x005a17d8
+char const* const s_UC_SUB_FARMS_005a17d8 = "UC_SUB_FARMS";
+
+// STRING: STRONGHOLDCRUSADER 0x005a17e8
+char const* const s_UC_SUB_AMUSEMENTS_005a17e8 = "UC_SUB_AMUSEMENTS";
+
+// STRING: STRONGHOLDCRUSADER 0x005a17fc
+char const* const s_UC_SUB_PUNISHMENTS_005a17fc = "UC_SUB_PUNISHMENTS";
+
+// STRING: STRONGHOLDCRUSADER 0x005a1810
+char const* const s_UC_SUB_CHURCHES_005a1810 = "UC_SUB_CHURCHES";
+
+// STRING: STRONGHOLDCRUSADER 0x005a1820
+char const* const s_UC_SUB_WORKSHOPS_005a1820 = "UC_SUB_WORKSHOPS";
+
+// STRING: STRONGHOLDCRUSADER 0x005a1834
+char const* const s_UC_SUB_DECORATION_005a1834 = "UC_SUB_DECORATION";
+
+// STRING: STRONGHOLDCRUSADER 0x005a1848
+char const* const s_UC_SUB_MILITARY_005a1848 = "UC_SUB_MILITARY";
+
+// STRING: STRONGHOLDCRUSADER 0x005a1858
+char const* const s_UC_SUB_GATEHOUSES_005a1858 = "UC_SUB_GATEHOUSES";
+
+// STRING: STRONGHOLDCRUSADER 0x005a186c
+char const* const s_UC_SUB_KEEPS_005a186c = "UC_SUB_KEEPS";
+
+// STRING: STRONGHOLDCRUSADER 0x005a187c
+char const* const s_UC_SUB_TOWERS_005a187c = "UC_SUB_TOWERS";
+
+// STRING: STRONGHOLDCRUSADER 0x005a188c
+char const* const s_UC_BLD_JOUSTING_005a188c = "UC_BLD_JOUSTING";
+
+// STRING: STRONGHOLDCRUSADER 0x005a189c
+char const* const s_UC_BLD_FAIR_005a189c = "UC_BLD_FAIR";
+
+// STRING: STRONGHOLDCRUSADER 0x005a18a8
+char const* const s_UC_BLD_FLOGGINGHORSE_005a18a8 = "UC_BLD_FLOGGINGHORSE";
+
+// STRING: STRONGHOLDCRUSADER 0x005a18c0
+char const* const s_UC_BLD_STAKE_005a18c0 = "UC_BLD_STAKE";
+
+// STRING: STRONGHOLDCRUSADER 0x005a18d0
+char const* const s_UC_BLD_DUNKINGSTOOL_005a18d0 = "UC_BLD_DUNKINGSTOOL";
+
+// STRING: STRONGHOLDCRUSADER 0x005a18e4
+char const* const s_UC_BLD_THUMBSCREW_005a18e4 = "UC_BLD_THUMBSCREW";
+
+// STRING: STRONGHOLDCRUSADER 0x005a18f8
+char const* const s_UC_BLD_FINGERPRESS_005a18f8 = "UC_BLD_FINGERPRESS";
+
+// STRING: STRONGHOLDCRUSADER 0x005a190c
+char const* const s_UC_BLD_GARDEN_12_005a190c = "UC_BLD_GARDEN_12";
+
+// STRING: STRONGHOLDCRUSADER 0x005a1920
+char const* const s_UC_BLD_GARDEN_11_005a1920 = "UC_BLD_GARDEN_11";
+
+// STRING: STRONGHOLDCRUSADER 0x005a1934
+char const* const s_UC_BLD_GARDEN_10_005a1934 = "UC_BLD_GARDEN_10";
+
+// STRING: STRONGHOLDCRUSADER 0x005a1948
+char const* const s_UC_BLD_GARDEN_9_005a1948 = "UC_BLD_GARDEN_9";
+
+// STRING: STRONGHOLDCRUSADER 0x005a1958
+char const* const s_UC_BLD_GARDEN_8_005a1958 = "UC_BLD_GARDEN_8";
+
+// STRING: STRONGHOLDCRUSADER 0x005a1968
+char const* const s_UC_BLD_GARDEN_7_005a1968 = "UC_BLD_GARDEN_7";
+
+// STRING: STRONGHOLDCRUSADER 0x005a1978
+char const* const s_UC_BLD_GARDEN_6_005a1978 = "UC_BLD_GARDEN_6";
+
+// STRING: STRONGHOLDCRUSADER 0x005a1988
+char const* const s_UC_BLD_GARDEN_5_005a1988 = "UC_BLD_GARDEN_5";
+
+// STRING: STRONGHOLDCRUSADER 0x005a1998
+char const* const s_UC_BLD_GARDEN_4_005a1998 = "UC_BLD_GARDEN_4";
+
+// STRING: STRONGHOLDCRUSADER 0x005a19a8
+char const* const s_UC_BLD_GARDEN_3_005a19a8 = "UC_BLD_GARDEN_3";
+
+// STRING: STRONGHOLDCRUSADER 0x005a19b8
+char const* const s_UC_BLD_GARDEN_2_005a19b8 = "UC_BLD_GARDEN_2";
+
+// STRING: STRONGHOLDCRUSADER 0x005a19c8
+char const* const s_UC_BLD_GARDEN_1_005a19c8 = "UC_BLD_GARDEN_1";
+
+// STRING: STRONGHOLDCRUSADER 0x005a19d8
+char const* const s_UC_BLD_CHURCH_3_005a19d8 = "UC_BLD_CHURCH_3";
+
+// STRING: STRONGHOLDCRUSADER 0x005a19e8
+char const* const s_UC_BLD_CHURCH_2_005a19e8 = "UC_BLD_CHURCH_2";
+
+// STRING: STRONGHOLDCRUSADER 0x005a19f8
+char const* const s_UC_BLD_CHURCH_1_005a19f8 = "UC_BLD_CHURCH_1";
+
+// STRING: STRONGHOLDCRUSADER 0x005a1a08
+char const* const s_UC_BLD_DWELLING_005a1a08 = "UC_BLD_DWELLING";
+
+// STRING: STRONGHOLDCRUSADER 0x005a1a18
+char const* const s_UC_AMUSEMENTS_005a1a18 = "UC_AMUSEMENTS";
+
+// STRING: STRONGHOLDCRUSADER 0x005a1a28
+char const* const s_UC_PUNISHMENTS_005a1a28 = "UC_PUNISHMENTS";
+
+// STRING: STRONGHOLDCRUSADER 0x005a1a38
+char const* const s_UC_GARDEN_005a1a38 = "UC_GARDEN";
+
+// STRING: STRONGHOLDCRUSADER 0x005a1a44
+char const* const s_UC_BANNER_005a1a44 = "UC_BANNER";
+
+// STRING: STRONGHOLDCRUSADER 0x005a1a50
+char const* const s_UC_CREST_2_005a1a50 = "UC_CREST_2";
+
+// STRING: STRONGHOLDCRUSADER 0x005a1a5c
+char const* const s_UC_CREST_005a1a5c = "UC_CREST";
+
+// STRING: STRONGHOLDCRUSADER 0x005a1a68
+char const* const s_UC_FLAG_3_005a1a68 = "UC_FLAG_3";
+
+// STRING: STRONGHOLDCRUSADER 0x005a1a74
+char const* const s_UC_FLAG_2_005a1a74 = "UC_FLAG_2";
+
+// STRING: STRONGHOLDCRUSADER 0x005a1a80
+char const* const s_UC_FLAG_1_005a1a80 = "UC_FLAG_1";
+
+// STRING: STRONGHOLDCRUSADER 0x005a1a8c
+char const* const s_UC_MILITARY_BUILDINGS_005a1a8c = "UC_MILITARY_BUILDINGS";
+
+// STRING: STRONGHOLDCRUSADER 0x005a1aa4
+char const* const s_UC_CASTLE_DECORATIONS_005a1aa4 = "UC_CASTLE_DECORATIONS";
+
+// STRING: STRONGHOLDCRUSADER 0x005a1abc
+char const* const s_UC_ANTIMOAT_005a1abc = "UC_ANTIMOAT";
+
+// STRING: STRONGHOLDCRUSADER 0x005a1ac8
+char const* const s_UC_BLD_STOCKS_005a1ac8 = "UC_BLD_STOCKS";
+
+// STRING: STRONGHOLDCRUSADER 0x005a1ad8
+char const* const s_UC_BLD_TROOP_TARGETS_005a1ad8 = "UC_BLD_TROOP_TARGETS";
+
+// STRING: STRONGHOLDCRUSADER 0x005a1af0
+char const* const s_UC_BLD_ARCHERY_TARGETS_005a1af0 = "UC_BLD_ARCHERY_TARGETS";
+
+// STRING: STRONGHOLDCRUSADER 0x005a1b08
+char const* const s_UC_BLD_MAYPOLE_005a1b08 = "UC_BLD_MAYPOLE";
+
+// STRING: STRONGHOLDCRUSADER 0x005a1b18
+char const* const s_UC_BLD_GALLOWS_005a1b18 = "UC_BLD_GALLOWS";
+
+// STRING: STRONGHOLDCRUSADER 0x005a1b28
+char const* const s_UC_BLD_PARAPETS_005a1b28 = "UC_BLD_PARAPETS";
+
+// STRING: STRONGHOLDCRUSADER 0x005a1b38
+char const* const s_UC_BLD_BARRED_WINDOWS_005a1b38 = "UC_BLD_BARRED_WINDOWS";
+
+// STRING: STRONGHOLDCRUSADER 0x005a1b50
+char const* const s_UC_BLD_LATRINES_005a1b50 = "UC_BLD_LATRINES";
+
+// STRING: STRONGHOLDCRUSADER 0x005a1b60
+char const* const s_UC_BLD_TUNNELER_005a1b60 = "UC_BLD_TUNNELER";
+
+// STRING: STRONGHOLDCRUSADER 0x005a1b70
+char const* const s_UC_BLD_ENGINEER_005a1b70 = "UC_BLD_ENGINEER";
+
+// STRING: STRONGHOLDCRUSADER 0x005a1b80
+char const* const s_UC_BLD_HEALER_005a1b80 = "UC_BLD_HEALER";
+
+// STRING: STRONGHOLDCRUSADER 0x005a1b90
+char const* const s_UC_BLD_INN_005a1b90 = "UC_BLD_INN";
+
+// STRING: STRONGHOLDCRUSADER 0x005a1b9c
+char const* const s_UC_BLD_CHURCHS_005a1b9c = "UC_BLD_CHURCHS";
+
+// STRING: STRONGHOLDCRUSADER 0x005a1bac
+char const* const s_UC_BLD_OX_TETHER_005a1bac = "UC_BLD_OX_TETHER";
+
+// STRING: STRONGHOLDCRUSADER 0x005a1bc0
+char const* const s_UC_BLD_FARM_HUNTER_005a1bc0 = "UC_BLD_FARM_HUNTER";
+
+// STRING: STRONGHOLDCRUSADER 0x005a1bd4
+char const* const s_UC_BLD_FARM_COWS_005a1bd4 = "UC_BLD_FARM_COWS";
+
+// STRING: STRONGHOLDCRUSADER 0x005a1be8
+char const* const s_UC_BLD_FARM_HOPS_005a1be8 = "UC_BLD_FARM_HOPS";
+
+// STRING: STRONGHOLDCRUSADER 0x005a1bfc
+char const* const s_UC_BLD_FARM_APPLE_005a1bfc = "UC_BLD_FARM_APPLE";
+
+// STRING: STRONGHOLDCRUSADER 0x005a1c10
+char const* const s_UC_BLD_FARM_WHEAT_005a1c10 = "UC_BLD_FARM_WHEAT";
+
+// STRING: STRONGHOLDCRUSADER 0x005a1c24
+char const* const s_UC_BLD_BREWER_005a1c24 = "UC_BLD_BREWER";
+
+// STRING: STRONGHOLDCRUSADER 0x005a1c34
+char const* const s_UC_BLD_BAKER_005a1c34 = "UC_BLD_BAKER";
+
+// STRING: STRONGHOLDCRUSADER 0x005a1c44
+char const* const s_UC_BLD_POLETURNER_005a1c44 = "UC_BLD_POLETURNER";
+
+// STRING: STRONGHOLDCRUSADER 0x005a1c58
+char const* const s_UC_BLD_FLETCHER_005a1c58 = "UC_BLD_FLETCHER";
+
+// STRING: STRONGHOLDCRUSADER 0x005a1c68
+char const* const s_UC_BLD_TANNER_005a1c68 = "UC_BLD_TANNER";
+
+// STRING: STRONGHOLDCRUSADER 0x005a1c78
+char const* const s_UC_BLD_ARMOURER_005a1c78 = "UC_BLD_ARMOURER";
+
+// STRING: STRONGHOLDCRUSADER 0x005a1c88
+char const* const s_UC_BLD_BLACKSMITH_005a1c88 = "UC_BLD_BLACKSMITH";
+
+// STRING: STRONGHOLDCRUSADER 0x005a1c9c
+char const* const s_UC_BLD_TRADEPOST_005a1c9c = "UC_BLD_TRADEPOST";
+
+// STRING: STRONGHOLDCRUSADER 0x005a1cb0
+char const* const s_UC_BLD_MILL_005a1cb0 = "UC_BLD_MILL";
+
+// STRING: STRONGHOLDCRUSADER 0x005a1cbc
+char const* const s_UC_BLD_WELL_005a1cbc = "UC_BLD_WELL";
+
+// STRING: STRONGHOLDCRUSADER 0x005a1cc8
+char const* const s_UC_BLD_GRANARY_005a1cc8 = "UC_BLD_GRANARY";
+
+// STRING: STRONGHOLDCRUSADER 0x005a1cd8
+char const* const s_UC_BLD_STOCKPILE_005a1cd8 = "UC_BLD_STOCKPILE";
+
+// STRING: STRONGHOLDCRUSADER 0x005a1cec
+char const* const s_UC_BLD_PITCH_DUGOUT_005a1cec = "UC_BLD_PITCH_DUGOUT";
+
+// STRING: STRONGHOLDCRUSADER 0x005a1d00
+char const* const s_UC_BLD_IRONMINE_005a1d00 = "UC_BLD_IRONMINE";
+
+// STRING: STRONGHOLDCRUSADER 0x005a1d10
+char const* const s_UC_BLD_WOODCUTTER_005a1d10 = "UC_BLD_WOODCUTTER";
+
+// STRING: STRONGHOLDCRUSADER 0x005a1d24
+char const* const s_UC_BLD_QUARRY_005a1d24 = "UC_BLD_QUARRY";
+
+// STRING: STRONGHOLDCRUSADER 0x005a1d34
+char const* const s_UC_BLD_HOUSE_005a1d34 = "UC_BLD_HOUSE";
+
+// STRING: STRONGHOLDCRUSADER 0x005a1d44
+char const* const s_UC_BLD_HOVEL_005a1d44 = "UC_BLD_HOVEL";
+
+// STRING: STRONGHOLDCRUSADER 0x005a1d54
+char const* const s_UC_WORKSHOPS_005a1d54 = "UC_WORKSHOPS";
+
+// STRING: STRONGHOLDCRUSADER 0x005a1d64
+char const* const s_UC_FARMS_005a1d64 = "UC_FARMS";
+
+// STRING: STRONGHOLDCRUSADER 0x005a1d70
+char const* const s_UC_KEEPS_E_005a1d70 = "UC_KEEPS_E";
+
+// STRING: STRONGHOLDCRUSADER 0x005a1d7c
+char const* const s_UC_KEEPS_D_005a1d7c = "UC_KEEPS_D";
+
+// STRING: STRONGHOLDCRUSADER 0x005a1d88
+char const* const s_UC_KEEPS_C_005a1d88 = "UC_KEEPS_C";
+
+// STRING: STRONGHOLDCRUSADER 0x005a1d94
+char const* const s_UC_KEEPS_B_005a1d94 = "UC_KEEPS_B";
+
+// STRING: STRONGHOLDCRUSADER 0x005a1da0
+char const* const s_UC_KEEPS_A_005a1da0 = "UC_KEEPS_A";
+
+// STRING: STRONGHOLDCRUSADER 0x005a1dac
+char const* const s_UC_MOAT_005a1dac = "UC_MOAT";
+
+// STRING: STRONGHOLDCRUSADER 0x005a1db4
+char const* const s_UC_DRAWBRIDGE_005a1db4 = "UC_DRAWBRIDGE";
+
+// STRING: STRONGHOLDCRUSADER 0x005a1dc4
+char const* const s_UC_GATE_LARGE_STONE_005a1dc4 = "UC_GATE_LARGE_STONE";
+
+// STRING: STRONGHOLDCRUSADER 0x005a1dd8
+char const* const s_UC_GATE_SMALL_STONE_005a1dd8 = "UC_GATE_SMALL_STONE";
+
+// STRING: STRONGHOLDCRUSADER 0x005a1dec
+char const* const s_UC_GATE_LARGE_WOODEN_005a1dec = "UC_GATE_LARGE_WOODEN";
+
+// STRING: STRONGHOLDCRUSADER 0x005a1e04
+char const* const s_UC_GATE_SMALL_WOODEN_005a1e04 = "UC_GATE_SMALL_WOODEN";
+
+// STRING: STRONGHOLDCRUSADER 0x005a1e1c
+char const* const s_UC_TOWER_F_005a1e1c = "UC_TOWER_F";
+
+// STRING: STRONGHOLDCRUSADER 0x005a1e28
+char const* const s_UC_TOWER_E_005a1e28 = "UC_TOWER_E";
+
+// STRING: STRONGHOLDCRUSADER 0x005a1e34
+char const* const s_UC_TOWER_D_005a1e34 = "UC_TOWER_D";
+
+// STRING: STRONGHOLDCRUSADER 0x005a1e40
+char const* const s_UC_TOWER_C_005a1e40 = "UC_TOWER_C";
+
+// STRING: STRONGHOLDCRUSADER 0x005a1e4c
+char const* const s_UC_TOWER_B_005a1e4c = "UC_TOWER_B";
+
+// STRING: STRONGHOLDCRUSADER 0x005a1e58
+char const* const s_UC_TOWER_A_005a1e58 = "UC_TOWER_A";
+
+// STRING: STRONGHOLDCRUSADER 0x005a1e64
+char const* const s_UC_SIEGE_TENT_3_005a1e64 = "UC_SIEGE_TENT_3";
+
+// STRING: STRONGHOLDCRUSADER 0x005a1e74
+char const* const s_UC_SIEGE_TENT_2_005a1e74 = "UC_SIEGE_TENT_2";
+
+// STRING: STRONGHOLDCRUSADER 0x005a1e84
+char const* const s_UC_SIEGE_TENT_1_005a1e84 = "UC_SIEGE_TENT_1";
+
+// STRING: STRONGHOLDCRUSADER 0x005a1e94
+char const* const s_UC_KILLING_PITS_005a1e94 = "UC_KILLING_PITS";
+
+// STRING: STRONGHOLDCRUSADER 0x005a1ea4
+char const* const s_UC_BRAZIER_005a1ea4 = "UC_BRAZIER";
+
+// STRING: STRONGHOLDCRUSADER 0x005a1eb0
+char const* const s_UC_WALL_WOODEN_005a1eb0 = "UC_WALL_WOODEN";
+
+// STRING: STRONGHOLDCRUSADER 0x005a1ec0
+char const* const s_UC_WALL_STAIRS_005a1ec0 = "UC_WALL_STAIRS";
+
+// STRING: STRONGHOLDCRUSADER 0x005a1ed0
+char const* const s_UC_WALL_CRENAL_005a1ed0 = "UC_WALL_CRENAL";
+
+// STRING: STRONGHOLDCRUSADER 0x005a1ee0
+char const* const s_UC_WALL_SINGLE_005a1ee0 = "UC_WALL_SINGLE";
+
+// STRING: STRONGHOLDCRUSADER 0x005a1ef0
+char const* const s_UC_BLD_STABLES_005a1ef0 = "UC_BLD_STABLES";
+
+// STRING: STRONGHOLDCRUSADER 0x005a1f00
+char const* const s_UC_BLD_BARRACKS_WOOD_005a1f00 = "UC_BLD_BARRACKS_WOOD";
+
+// STRING: STRONGHOLDCRUSADER 0x005a1f18
+char const* const s_UC_BLD_BARRACKS_STONE_005a1f18 = "UC_BLD_BARRACKS_STONE";
+
+// STRING: STRONGHOLDCRUSADER 0x005a1f30
+char const* const s_UC_BLD_ARMOURY_005a1f30 = "UC_BLD_ARMOURY";
+
+// STRING: STRONGHOLDCRUSADER 0x005a1f40
+char const* const s_UC_KEEPS_005a1f40 = "UC_KEEPS";
+
+// STRING: STRONGHOLDCRUSADER 0x005a1f4c
+char const* const s_UC_GATEHOUSES_005a1f4c = "UC_GATEHOUSES";
+
+// STRING: STRONGHOLDCRUSADER 0x005a1f5c
+char const* const s_UC_TOWERS_005a1f5c = "UC_TOWERS";
+
+// STRING: STRONGHOLDCRUSADER 0x005a1f68
+char const* const s_logo2_tgx_005a1f68 = "logo2.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005a1f74
+char const* const s_logo1_tgx_005a1f74 = "logo1.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005a1f80
+char const* const s_intro_bik_005a1f80 = "intro.bik";
+
+// STRING: STRONGHOLDCRUSADER 0x005a1f8c
+char const* const s_shc_back_tgx_005a1f8c = "shc_back.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005a1f9c
+char const* const s_frontend_main2_tgx_005a1f9c = "frontend_main2.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005a1fb0
+char const* const s_frontend_main_tgx_005a1fb0 = "frontend_main.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005a1fc4
+char const* const s_richard_swordswing_bik_005a1fc4 = "richard_swordswing.bik";
+
+// STRING: STRONGHOLDCRUSADER 0x005a1fdc
+char const* const s_V1_d_005a1fdc = "V1.%d";
+
+// STRING: STRONGHOLDCRUSADER 0x005a1fe4
+char const* const s_richard_ambient_bik_005a1fe4 = "richard_ambient.bik";
+
+// STRING: STRONGHOLDCRUSADER 0x005a1ff8
+char const* const s_Crusader_tutorial_map_005a1ff8 = "Crusader_tutorial.map";
+
+// STRING: STRONGHOLDCRUSADER 0x005a2010
+char const* const s_frontend_combat2_tgx_005a2010 = "frontend_combat2.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005a2028
+char const* const s_frontend_combat_tgx_005a2028 = "frontend_combat.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005a203c
+char const* const s_frontend_economics2_tgx_005a203c = "frontend_economics2.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005a2054
+char const* const s_frontend_economics_tgx_005a2054 = "frontend_economics.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005a206c
+char const* const s_frontend_builder2_tgx_005a206c = "frontend_builder2.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005a2084
+char const* const s_frontend_builder_tgx_005a2084 = "frontend_builder.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005a209c
+char const* const s_credits_hlp_005a209c = "credits.hlp";
+
+// STRING: STRONGHOLDCRUSADER 0x005a20a8
+char const* const s_end_credit_tgx_005a20a8 = "end_credit.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005a20b8
+char const* const s_credits_4_tgx_005a20b8 = "credits_4.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005a20c8
+char const* const s_credits_3_tgx_005a20c8 = "credits_3.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005a20d8
+char const* const s_credits_2_tgx_005a20d8 = "credits_2.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005a20e8
+char const* const s_credits_1_tgx_005a20e8 = "credits_1.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005a20f8
+char const* const s_demo_buy_it_screen_tgx_005a20f8 = "demo buy it screen.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005a2110
+char const* const s_gm_fly_tgx_005a2110 = "gm_fly.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005a211c
+char const* const s_multi_background_tgx_005a211c = "multi_background.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005a2134
+char const* const s_frontend_combat3_tgx_005a2134 = "frontend_combat3.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005a214c
+char const* const s_pick_opponent_large_tgx_005a214c = "pick_opponent_large.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005a2164
+char const* const s_pick_opponent_normal_tgx_005a2164 = "pick_opponent_normal.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005a2180
+char const* const s_tslice8b_tgx_005a2180 = "tslice8b.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005a2190
+char const* const s_tslice7b_tgx_005a2190 = "tslice7b.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005a21a0
+char const* const s_tslice6b_tgx_005a21a0 = "tslice6b.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005a21b0
+char const* const s_tslice5b_tgx_005a21b0 = "tslice5b.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005a21c0
+char const* const s_tslice4b_tgx_005a21c0 = "tslice4b.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005a21d0
+char const* const s_tslice3b_tgx_005a21d0 = "tslice3b.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005a21e0
+char const* const s_tslice2b_tgx_005a21e0 = "tslice2b.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005a21f0
+char const* const s_tslice1b_tgx_005a21f0 = "tslice1b.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005a2200
+char const* const s_tslice8_tgx_005a2200 = "tslice8.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005a220c
+char const* const s_tslice7_tgx_005a220c = "tslice7.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005a2218
+char const* const s_tslice6_tgx_005a2218 = "tslice6.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005a2224
+char const* const s_tslice5_tgx_005a2224 = "tslice5.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005a2230
+char const* const s_tslice4_tgx_005a2230 = "tslice4.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005a223c
+char const* const s_tslice3_tgx_005a223c = "tslice3.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005a2248
+char const* const s_tslice2_tgx_005a2248 = "tslice2.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005a2254
+char const* const s_tslice1_tgx_005a2254 = "tslice1.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005a2260
+char const* const s_table_tgx_005a2260 = "table.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005a226c
+char const* const s_firefly_small_tgx_005a226c = "firefly-small.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005a2280
+char const* const s___005a2280 = "-";
+
+// STRING: STRONGHOLDCRUSADER 0x005a2284
+char const* const s__s__d_005a2284 = "%s :%d";
+
+// STRING: STRONGHOLDCRUSADER 0x005a228c
+char const* const s__s__s_005a228c = "%s :%s";
+
+// STRING: STRONGHOLDCRUSADER 0x005a2294
+char const* const s__map_005a2294 = ".map";
+
+// STRING: STRONGHOLDCRUSADER 0x005a229c
+char const* const s__02d_02d_02d__02d_02d_005a229c = "%02d/%02d/%02d %02d:%02d";
+
+// STRING: STRONGHOLDCRUSADER 0x005a22b8
+char const* const s_Crusader_005a22b8 = "Crusader";
+
+// STRING: STRONGHOLDCRUSADER 0x005a22c4
+char const* const s_FireFly_s_005a22c4 = "FireFly's";
+
+// STRING: STRONGHOLDCRUSADER 0x005a22d8
+char const* const s_Continue_005a22d8 = "Continue";
+
+// STRING: STRONGHOLDCRUSADER 0x005a22e4
+char const* const s_Test_map_005a22e4 = "Test map";
+
+// STRING: STRONGHOLDCRUSADER 0x005a22f0
+char const* const s_Game_Paused_005a22f0 = "Game Paused";
+
+// STRING: STRONGHOLDCRUSADER 0x005a22fc
+char const* const s__dx_d_005a22fc = "%dx%d";
+
+// STRING: STRONGHOLDCRUSADER 0x005a2304
+char const* const s___005a2304 = " - ";
+
+// STRING: STRONGHOLDCRUSADER 0x005a2308
+char const* const s_edge1680l_tgx_005a2308 = "edge1680l.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005a2318
+char const* const s_edge1360l_tgx_005a2318 = "edge1360l.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005a2328
+char const* const s_edge1366l_tgx_005a2328 = "edge1366l.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005a2338
+char const* const s_edge2560l_tgx_005a2338 = "edge2560l.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005a2348
+char const* const s_edge1920l_tgx_005a2348 = "edge1920l.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005a2358
+char const* const s_edge1440l_tgx_005a2358 = "edge1440l.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005a2368
+char const* const s_edge1600l_tgx_005a2368 = "edge1600l.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005a2378
+char const* const s_edge1280l_tgx_005a2378 = "edge1280l.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005a2388
+char const* const s_edge1024l_tgx_005a2388 = "edge1024l.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005a2398
+char const* const s_edge1680r_tgx_005a2398 = "edge1680r.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005a23a8
+char const* const s_edge1360r_tgx_005a23a8 = "edge1360r.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005a23b8
+char const* const s_edge1366r_tgx_005a23b8 = "edge1366r.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005a23c8
+char const* const s_edge2560r_tgx_005a23c8 = "edge2560r.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005a23d8
+char const* const s_edge1920r_tgx_005a23d8 = "edge1920r.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005a23e8
+char const* const s_edge1440r_tgx_005a23e8 = "edge1440r.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005a23f8
+char const* const s_edge1600r_tgx_005a23f8 = "edge1600r.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005a2408
+char const* const s_edge1280r_tgx_005a2408 = "edge1280r.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005a2418
+char const* const s_edge1024r_tgx_005a2418 = "edge1024r.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005a2428
+char const* const s_edge_military_1680r_tgx_005a2428 = "edge_military_1680r.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005a2440
+char const* const s_edge_military_1680l_tgx_005a2440 = "edge_military_1680l.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005a2458
+char const* const s_edge_military_1360r_tgx_005a2458 = "edge_military_1360r.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005a2470
+char const* const s_edge_military_1360l_tgx_005a2470 = "edge_military_1360l.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005a2488
+char const* const s_edge_military_1366r_tgx_005a2488 = "edge_military_1366r.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005a24a0
+char const* const s_edge_military_1366l_tgx_005a24a0 = "edge_military_1366l.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005a24b8
+char const* const s_edge_military_2560r_tgx_005a24b8 = "edge_military_2560r.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005a24d0
+char const* const s_edge_military_2560l_tgx_005a24d0 = "edge_military_2560l.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005a24e8
+char const* const s_edge_military_1920r_tgx_005a24e8 = "edge_military_1920r.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005a2500
+char const* const s_edge_military_1920l_tgx_005a2500 = "edge_military_1920l.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005a2518
+char const* const s_edge_military_1440r_tgx_005a2518 = "edge_military_1440r.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005a2530
+char const* const s_edge_military_1440l_tgx_005a2530 = "edge_military_1440l.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005a2548
+char const* const s_edge_military_1600r_tgx_005a2548 = "edge_military_1600r.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005a2560
+char const* const s_edge_military_1600l_tgx_005a2560 = "edge_military_1600l.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005a2578
+char const* const s_edge_military_1280r_tgx_005a2578 = "edge_military_1280r.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005a2590
+char const* const s_edge_military_1280l_tgx_005a2590 = "edge_military_1280l.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005a25a8
+char const* const s_edge_military_1024r_tgx_005a25a8 = "edge_military_1024r.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005a25c0
+char const* const s_edge_military_1024l_tgx_005a25c0 = "edge_military_1024l.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005a25d8
+char const* const s_Path_linkage_005a25d8 = "Path linkage";
+
+// STRING: STRONGHOLDCRUSADER 0x005a25e8
+char const* const s_Connect_005a25e8 = "Connect";
+
+// STRING: STRONGHOLDCRUSADER 0x005a27cc
+char const* const SFX_YourAllies = "Genie_11.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a27dc
+char const* const s_religion_sketch_tgx_005a27dc = "religion_sketch.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005a27f0
+char const* const s_churchs_tgx_005a27f0 = "churchs.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005a27fc
+char const* const s_armys26_tgx_005a27fc = "armys26.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005a2808
+char const* const s_armys25_tgx_005a2808 = "armys25.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005a2814
+char const* const s_armys24_tgx_005a2814 = "armys24.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005a2820
+char const* const s_armys23_tgx_005a2820 = "armys23.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005a282c
+char const* const s_armys22_tgx_005a282c = "armys22.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005a2838
+char const* const s_armys21_tgx_005a2838 = "armys21.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005a2844
+char const* const s_armys20_tgx_005a2844 = "armys20.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005a2850
+char const* const s_armys19_tgx_005a2850 = "armys19.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005a285c
+char const* const s_armys18_tgx_005a285c = "armys18.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005a2868
+char const* const s_armys17_tgx_005a2868 = "armys17.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005a2874
+char const* const s_armys16_tgx_005a2874 = "armys16.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005a2880
+char const* const s_armys15_tgx_005a2880 = "armys15.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005a288c
+char const* const s_armys14_tgx_005a288c = "armys14.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005a2898
+char const* const s_armys13_tgx_005a2898 = "armys13.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005a28a4
+char const* const s_armys12_tgx_005a28a4 = "armys12.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005a28b0
+char const* const s_armys11_tgx_005a28b0 = "armys11.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005a28bc
+char const* const s_armys10_tgx_005a28bc = "armys10.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005a28c8
+char const* const s_armys9_tgx_005a28c8 = "armys9.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005a28d4
+char const* const s_armys8_tgx_005a28d4 = "armys8.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005a28e0
+char const* const s_armys7_tgx_005a28e0 = "armys7.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005a28ec
+char const* const s_armys6_tgx_005a28ec = "armys6.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005a28f8
+char const* const s_armys5_tgx_005a28f8 = "armys5.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005a2904
+char const* const s_armys4_tgx_005a2904 = "armys4.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005a2910
+char const* const s_armys3_tgx_005a2910 = "armys3.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005a291c
+char const* const s_armys2_tgx_005a291c = "armys2.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005a2928
+char const* const s_armys1_tgx_005a2928 = "armys1.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005a2934
+char const* const s_armyrbd_tgx_005a2934 = "armyrbd.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005a2940
+char const* const s_armylbd_tgx_005a2940 = "armylbd.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005a294c
+char const* const s_armybar_tgx_005a294c = "armybar.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005a2958
+char const* const s_armysbar_tgx_005a2958 = "armysbar.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005a2968
+char const* const s_food_sketch_tgx_005a2968 = "food_sketch.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005a2978
+char const* const s_population_sketch_tgx_005a2978 = "population_sketch.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005a2990
+char const* const s_popgraph_tgx_005a2990 = "popgraph.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005a29a0
+char const* const SFX_PeopleWorshipYouAsKindestMan = "general_fear10.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a29b4
+char const* const SFX_PeopleThinkYouAreReallyNice = "general_fear8.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a29c8
+char const* const SFX_PeopleThinkYouAreFantastic = "general_fear9.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a29dc
+char const* const SFX_PeopleAreNotAfraidOfYouAtAll = "general_fear7.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a29f0
+char const* const SFX_PeopleTrustYouMyLord = "general_fear6.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a2a04
+char const* const SFX_PeopleAreALittleAfraid = "general_fear5.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a2a18
+char const* const SFX_PeopleAreFrightened = "general_fear4.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a2a2c
+char const* const SFX_PeopleAreVeryScared = "general_fear3.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a2a40
+char const* const SFX_PeopleTrembleAtYourName = "general_fear2.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a2a54
+char const* const SFX_CruellestTyrantInTheKingdom = "general_fear1.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a2a68
+char const* const s_fearfneg_tgx_005a2a68 = "fearfneg.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005a2a78
+char const* const s_fearfpos_tgx_005a2a78 = "fearfpos.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005a2a88
+char const* const s_popularity_sketch_tgx_005a2a88 = "popularity_sketch.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005a2aa0
+char const* const s_shield2_tgx_005a2aa0 = "shield2.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005a2aac
+char const* const s_shield1_tgx_005a2aac = "shield1.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005a2ab8
+char const* const s_wedding_sketch_tgx_005a2ab8 = "wedding_sketch.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005a2acc
+char const* const s_food_warning5_wav_005a2acc = "food_warning5.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a2ae0
+char const* const s_aengineer_pouroil9_wav_005a2ae0 = "aengineer_pouroil9.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a2af8
+char const* const s_engineer_pouroil9_wav_005a2af8 = "engineer_pouroil9.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a2b10
+char const* const s_aengineer_pouroil8_wav_005a2b10 = "aengineer_pouroil8.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a2b28
+char const* const s_engineer_pouroil8_wav_005a2b28 = "engineer_pouroil8.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a2b40
+char const* const s_aengineer_pouroil7_wav_005a2b40 = "aengineer_pouroil7.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a2b58
+char const* const s_engineer_pouroil7_wav_005a2b58 = "engineer_pouroil7.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a2b70
+char const* const s_aengineer_pouroil1_wav_005a2b70 = "aengineer_pouroil1.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a2b88
+char const* const s_engineer_pouroil1_wav_005a2b88 = "engineer_pouroil1.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a2ba0
+char const* const s_aengineer_launchcow6_wav_005a2ba0 = "aengineer_launchcow6.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a2bbc
+char const* const s_engineer_launchcow6_wav_005a2bbc = "engineer_launchcow6.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a2bd4
+char const* const s_aengineer_launchcow5_wav_005a2bd4 = "aengineer_launchcow5.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a2bf0
+char const* const s_engineer_launchcow5_wav_005a2bf0 = "engineer_launchcow5.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a2c08
+char const* const s_aengineer_launchcow4_wav_005a2c08 = "aengineer_launchcow4.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a2c24
+char const* const s_engineer_launchcow4_wav_005a2c24 = "engineer_launchcow4.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a2c3c
+char const* const s_aengineer_launchcow3_wav_005a2c3c = "aengineer_launchcow3.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a2c58
+char const* const s_engineer_launchcow3_wav_005a2c58 = "engineer_launchcow3.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a2c70
+char const* const s_aengineer_launchcow2_wav_005a2c70 = "aengineer_launchcow2.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a2c8c
+char const* const s_engineer_launchcow2_wav_005a2c8c = "engineer_launchcow2.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a2ca4
+char const* const s_aengineer_launchcow1_wav_005a2ca4 = "aengineer_launchcow1.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a2cc0
+char const* const s_engineer_launchcow1_wav_005a2cc0 = "engineer_launchcow1.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a2cd8
+char const* const s_aengineer_manoil1_wav_005a2cd8 = "aengineer_manoil1.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a2cf0
+char const* const s_engineer_manoil1_wav_005a2cf0 = "engineer_manoil1.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a2d08
+char const* const s_aengineer_mansmelter1_wav_005a2d08 = "aengineer_mansmelter1.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a2d24
+char const* const s_engineer_mansmelter1_wav_005a2d24 = "engineer_mansmelter1.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a2d40
+char const* const s_aengineer_pouroil6_wav_005a2d40 = "aengineer_pouroil6.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a2d58
+char const* const s_engineer_pouroil6_wav_005a2d58 = "engineer_pouroil6.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a2d70
+char const* const s_aengineer_pouroil5_wav_005a2d70 = "aengineer_pouroil5.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a2d88
+char const* const s_engineer_pouroil5_wav_005a2d88 = "engineer_pouroil5.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a2da0
+char const* const s_aengineer_pouroil4_wav_005a2da0 = "aengineer_pouroil4.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a2db8
+char const* const s_engineer_pouroil4_wav_005a2db8 = "engineer_pouroil4.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a2dd0
+char const* const s_aengineer_pouroil3_wav_005a2dd0 = "aengineer_pouroil3.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a2de8
+char const* const s_engineer_pouroil3_wav_005a2de8 = "engineer_pouroil3.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a2e00
+char const* const s_aengineer_pouroil2_wav_005a2e00 = "aengineer_pouroil2.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a2e18
+char const* const s_engineer_pouroil2_wav_005a2e18 = "engineer_pouroil2.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a2e30
+char const* const s_aengineer_exit1_wav_005a2e30 = "aengineer_exit1.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a2e44
+char const* const s_engineer_exit1_wav_005a2e44 = "engineer_exit1.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a2e58
+char const* const s_aengineer_build1_wav_005a2e58 = "aengineer_build1.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a2e70
+char const* const s_engineer_build1_wav_005a2e70 = "engineer_build1.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a2e84
+char const* const s_aengineer_manequip1_wav_005a2e84 = "aengineer_manequip1.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a2e9c
+char const* const s_engineer_manequip1_wav_005a2e9c = "engineer_manequip1.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a2eb4
+char const* const s_aengineer_ram1_wav_005a2eb4 = "aengineer_ram1.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a2ec8
+char const* const s_engineer_ram1_wav_005a2ec8 = "engineer_ram1.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a2edc
+char const* const s_aengineer_balis1_wav_005a2edc = "aengineer_balis1.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a2ef4
+char const* const s_engineer_balis1_wav_005a2ef4 = "engineer_balis1.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a2f08
+char const* const s_aengineer_treb1_wav_005a2f08 = "aengineer_treb1.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a2f1c
+char const* const s_engineer_treb1_wav_005a2f1c = "engineer_treb1.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a2f30
+char const* const s_aengineer_catplt1_wav_005a2f30 = "aengineer_catplt1.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a2f48
+char const* const s_engineer_catplt1_wav_005a2f48 = "engineer_catplt1.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a2f60
+char const* const s_aengineer_mang1_wav_005a2f60 = "aengineer_mang1.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a2f74
+char const* const s_engineer_mang1_wav_005a2f74 = "engineer_mang1.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a2f88
+char const* const s_aengineer_equip4_wav_005a2f88 = "aengineer_equip4.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a2fa0
+char const* const s_engineer_equip4_wav_005a2fa0 = "engineer_equip4.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a2fb4
+char const* const s_aengineer_equip3_wav_005a2fb4 = "aengineer_equip3.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a2fcc
+char const* const s_engineer_equip3_wav_005a2fcc = "engineer_equip3.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a2fe0
+char const* const s_aengineer_equip2_wav_005a2fe0 = "aengineer_equip2.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a2ff8
+char const* const s_engineer_equip2_wav_005a2ff8 = "engineer_equip2.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a300c
+char const* const s_aengineer_equip1_wav_005a300c = "aengineer_equip1.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a3024
+char const* const s_engineer_equip1_wav_005a3024 = "engineer_equip1.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a3038
+char const* const s_aengineer_mshield_wav_005a3038 = "aengineer_mshield.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a3050
+char const* const s_engineer_mshield_wav_005a3050 = "engineer_mshield.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a3068
+char const* const s_aengineer_mram_wav_005a3068 = "aengineer_mram.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a307c
+char const* const s_engineer_mram_wav_005a307c = "engineer_mram.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a3090
+char const* const s_aengineer_mtower_wav_005a3090 = "aengineer_mtower.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a30a8
+char const* const s_engineer_mtower_wav_005a30a8 = "engineer_mtower.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a30bc
+char const* const s_aengineer_mcatplt_wav_005a30bc = "aengineer_mcatplt.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a30d4
+char const* const s_engineer_mcatplt_wav_005a30d4 = "engineer_mcatplt.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a30ec
+char const* const s_aengineer_sbalis_wav_005a30ec = "aengineer_sbalis.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a3104
+char const* const s_engineer_sbalis_wav_005a3104 = "engineer_sbalis.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a3118
+char const* const s_aengineer_sshield_wav_005a3118 = "aengineer_sshield.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a3130
+char const* const s_engineer_sshield_wav_005a3130 = "engineer_sshield.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a3148
+char const* const s_aengineer_sram_wav_005a3148 = "aengineer_sram.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a315c
+char const* const s_engineer_sram_wav_005a315c = "engineer_sram.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a3170
+char const* const s_aengineer_stower_wav_005a3170 = "aengineer_stower.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a3188
+char const* const s_engineer_stower_wav_005a3188 = "engineer_stower.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a319c
+char const* const s_aengineer_streb_wav_005a319c = "aengineer_streb.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a31b0
+char const* const s_engineer_streb_wav_005a31b0 = "engineer_streb.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a31c4
+char const* const s_aengineer_scatplt_wav_005a31c4 = "aengineer_scatplt.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a31dc
+char const* const s_engineer_scatplt_wav_005a31dc = "engineer_scatplt.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a31f4
+char const* const s_aengineer_sman_wav_005a31f4 = "aengineer_sman.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a3208
+char const* const SFX_MangonelReadySire = "engineer_sman.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a321c
+char const* const s_ahorse_disband1_wav_005a321c = "ahorse_disband1.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a3230
+char const* const s_asword_disband1_wav_005a3230 = "asword_disband1.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a3244
+char const* const s_agrenadier_disband1_wav_005a3244 = "agrenadier_disband1.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a325c
+char const* const s_aslave_disband1_wav_005a325c = "aslave_disband1.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a3270
+char const* const s_aassasin_disband1_wav_005a3270 = "aassasin_disband1.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a3288
+char const* const s_asling_disband1_wav_005a3288 = "asling_disband1.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a329c
+char const* const s_abow_disband1_wav_005a329c = "abow_disband1.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a32b0
+char const* const s_engineer_disband1_wav_005a32b0 = "engineer_disband1.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a32c8
+char const* const s_ladder_disband1_wav_005a32c8 = "ladder_disband1.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a32dc
+char const* const s_tunnel_disband1_wav_005a32dc = "tunnel_disband1.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a32f0
+char const* const s_monk_disband1_wav_005a32f0 = "monk_disband1.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a3304
+char const* const s_knight_disband1_wav_005a3304 = "knight_disband1.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a3318
+char const* const s_sword_disband1_wav_005a3318 = "sword_disband1.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a332c
+char const* const s_pike_disband1_wav_005a332c = "pike_disband1.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a3340
+char const* const s_mace_disband1_wav_005a3340 = "mace_disband1.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a3354
+char const* const s_spear_disband1_wav_005a3354 = "spear_disband1.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a3368
+char const* const s_cross_disband1_wav_005a3368 = "cross_disband1.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a337c
+char const* const s_arch_disband1_wav_005a337c = "arch_disband1.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a3390
+char const* const s_tunnel_digtunnel2_wav_005a3390 = "tunnel_digtunnel2.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a33a8
+char const* const s_tunnel_digtunnel1_wav_005a33a8 = "tunnel_digtunnel1.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a33c0
+char const* const SFX_LaddermanGetThoseLaddersUp = "ladder_placeladder3.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a33d8
+char const* const SFX_LaddermanLaddersReady = "ladder_placeladder2.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a33f0
+char const* const SFX_LaddermanToTheWalls = "ladder_placeladder1.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a3408
+char const* const s_spear_ladder3_wav_005a3408 = "spear_ladder3.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a341c
+char const* const s_spear_ladder2_wav_005a341c = "spear_ladder2.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a3430
+char const* const s_spear_ladder1_wav_005a3430 = "spear_ladder1.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a3444
+char const* const s_abow_atk_eqp1_wav_005a3444 = "abow_atk_eqp1.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a3458
+char const* const s_arch_atk_eqp1_wav_005a3458 = "arch_atk_eqp1.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a346c
+char const* const s_abow_light_pitch1_wav_005a346c = "abow_light_pitch1.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a3484
+char const* const s_arch_light_pitch1_wav_005a3484 = "arch_light_pitch1.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a349c
+char const* const s_asling_atknt_wav_005a349c = "asling_atknt.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a34b0
+char const* const s_abow_atknt_wav_005a34b0 = "abow_atknt.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a34c0
+char const* const s_cross_atknt_wav_005a34c0 = "cross_atknt.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a34d0
+char const* const s_arch_atknt_wav_005a34d0 = "arch_atknt.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a34e0
+char const* const s_ahorse_atka1_wav_005a34e0 = "ahorse_atka1.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a34f4
+char const* const s_asling_atka1_wav_005a34f4 = "asling_atka1.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a3508
+char const* const s_abow_atka1_wav_005a3508 = "abow_atka1.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a3518
+char const* const s_cross_atka1_wav_005a3518 = "cross_atka1.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a3528
+char const* const s_arch_atka1_wav_005a3528 = "arch_atka1.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a3538
+char const* const s_ahorse_atkm4_wav_005a3538 = "ahorse_atkm4.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a354c
+char const* const s_agrenadier_atkm4_wav_005a354c = "agrenadier_atkm4.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a3564
+char const* const s_asling_atkm4_wav_005a3564 = "asling_atkm4.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a3578
+char const* const s_abow_atkm4_wav_005a3578 = "abow_atkm4.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a3588
+char const* const s_cross_atkm4_wav_005a3588 = "cross_atkm4.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a3598
+char const* const s_arch_atkm4_wav_005a3598 = "arch_atkm4.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a35a8
+char const* const s_ahorse_atkm3_wav_005a35a8 = "ahorse_atkm3.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a35bc
+char const* const s_agrenadier_atkm3_wav_005a35bc = "agrenadier_atkm3.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a35d4
+char const* const s_asling_atkm3_wav_005a35d4 = "asling_atkm3.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a35e8
+char const* const s_abow_atkm3_wav_005a35e8 = "abow_atkm3.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a35f8
+char const* const s_cross_atkm3_wav_005a35f8 = "cross_atkm3.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a3608
+char const* const s_arch_atkm3_wav_005a3608 = "arch_atkm3.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a3618
+char const* const s_ahorse_atkm2_wav_005a3618 = "ahorse_atkm2.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a362c
+char const* const s_agrenadier_atkm2_wav_005a362c = "agrenadier_atkm2.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a3644
+char const* const s_asling_atkm2_wav_005a3644 = "asling_atkm2.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a3658
+char const* const s_abow_atkm2_wav_005a3658 = "abow_atkm2.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a3668
+char const* const s_cross_atkm2_wav_005a3668 = "cross_atkm2.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a3678
+char const* const s_arch_atkm2_wav_005a3678 = "arch_atkm2.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a3688
+char const* const s_ahorse_atkm1_wav_005a3688 = "ahorse_atkm1.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a369c
+char const* const s_agrenadier_atkm1_wav_005a369c = "agrenadier_atkm1.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a36b4
+char const* const s_asling_atkm1_wav_005a36b4 = "asling_atkm1.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a36c8
+char const* const s_abow_atkm1_wav_005a36c8 = "abow_atkm1.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a36d8
+char const* const s_cross_atkm1_wav_005a36d8 = "cross_atkm1.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a36e8
+char const* const s_arch_atkm1_wav_005a36e8 = "arch_atkm1.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a36f8
+char const* const s_asword_atkw4_wav_005a36f8 = "asword_atkw4.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a370c
+char const* const s_aassasin_atkw4_wav_005a370c = "aassasin_atkw4.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a3720
+char const* const s_engineer_atkw4_wav_005a3720 = "engineer_atkw4.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a3734
+char const* const s_ladder_atkw4_wav_005a3734 = "ladder_atkw4.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a3748
+char const* const s_tunnel_atkw4_wav_005a3748 = "tunnel_atkw4.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a375c
+char const* const s_monk_atkw4_wav_005a375c = "monk_atkw4.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a376c
+char const* const s_knight_atkw4_wav_005a376c = "knight_atkw4.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a3780
+char const* const s_sword_atkw4_wav_005a3780 = "sword_atkw4.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a3790
+char const* const s_pike_atkw4_wav_005a3790 = "pike_atkw4.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a37a0
+char const* const s_mace_atkw4_wav_005a37a0 = "mace_atkw4.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a37b0
+char const* const s_spear_atkw4_wav_005a37b0 = "spear_atkw4.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a37c0
+char const* const s_asword_atkw3_wav_005a37c0 = "asword_atkw3.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a37d4
+char const* const s_aassasin_atkw3_wav_005a37d4 = "aassasin_atkw3.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a37e8
+char const* const s_engineer_atkw3_wav_005a37e8 = "engineer_atkw3.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a37fc
+char const* const s_ladder_atkw3_wav_005a37fc = "ladder_atkw3.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a3810
+char const* const s_tunnel_atkw3_wav_005a3810 = "tunnel_atkw3.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a3824
+char const* const s_monk_atkw3_wav_005a3824 = "monk_atkw3.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a3834
+char const* const s_knight_atkw3_wav_005a3834 = "knight_atkw3.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a3848
+char const* const s_sword_atkw3_wav_005a3848 = "sword_atkw3.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a3858
+char const* const s_pike_atkw3_wav_005a3858 = "pike_atkw3.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a3868
+char const* const s_mace_atkw3_wav_005a3868 = "mace_atkw3.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a3878
+char const* const s_spear_atkw3_wav_005a3878 = "spear_atkw3.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a3888
+char const* const s_asword_atkw2_wav_005a3888 = "asword_atkw2.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a389c
+char const* const s_aassasin_atkw2_wav_005a389c = "aassasin_atkw2.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a38b0
+char const* const s_engineer_atkw2_wav_005a38b0 = "engineer_atkw2.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a38c4
+char const* const s_ladder_atkw2_wav_005a38c4 = "ladder_atkw2.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a38d8
+char const* const s_tunnel_atkw2_wav_005a38d8 = "tunnel_atkw2.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a38ec
+char const* const s_monk_atkw2_wav_005a38ec = "monk_atkw2.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a38fc
+char const* const s_knight_atkw2_wav_005a38fc = "knight_atkw2.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a3910
+char const* const s_sword_atkw2_wav_005a3910 = "sword_atkw2.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a3920
+char const* const s_pike_atkw2_wav_005a3920 = "pike_atkw2.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a3930
+char const* const s_mace_atkw2_wav_005a3930 = "mace_atkw2.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a3940
+char const* const s_spear_atkw2_wav_005a3940 = "spear_atkw2.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a3950
+char const* const s_asword_atkw1_wav_005a3950 = "asword_atkw1.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a3964
+char const* const s_aassasin_atkw1_wav_005a3964 = "aassasin_atkw1.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a3978
+char const* const s_engineer_atkw1_wav_005a3978 = "engineer_atkw1.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a398c
+char const* const s_ladder_atkw1_wav_005a398c = "ladder_atkw1.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a39a0
+char const* const s_tunnel_atkw1_wav_005a39a0 = "tunnel_atkw1.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a39b4
+char const* const s_monk_atkw1_wav_005a39b4 = "monk_atkw1.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a39c4
+char const* const s_knight_atkw1_wav_005a39c4 = "knight_atkw1.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a39d8
+char const* const s_sword_atkw1_wav_005a39d8 = "sword_atkw1.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a39e8
+char const* const s_pike_atkw1_wav_005a39e8 = "pike_atkw1.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a39f8
+char const* const s_mace_atkw1_wav_005a39f8 = "mace_atkw1.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a3a08
+char const* const s_spear_atkw1_wav_005a3a08 = "spear_atkw1.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a3a18
+char const* const s_aassasin_atks4_wav_005a3a18 = "aassasin_atks4.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a3a2c
+char const* const s_engineer_atks4_wav_005a3a2c = "engineer_atks4.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a3a40
+char const* const s_ladder_atks4_wav_005a3a40 = "ladder_atks4.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a3a54
+char const* const s_tunnel_atks4_wav_005a3a54 = "tunnel_atks4.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a3a68
+char const* const s_monk_atks4_wav_005a3a68 = "monk_atks4.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a3a78
+char const* const s_knight_atks4_wav_005a3a78 = "knight_atks4.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a3a8c
+char const* const s_sword_atks4_wav_005a3a8c = "sword_atks4.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a3a9c
+char const* const s_pike_atks4_wav_005a3a9c = "pike_atks4.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a3aac
+char const* const s_mace_atks4_wav_005a3aac = "mace_atks4.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a3abc
+char const* const s_spear_atks4_wav_005a3abc = "spear_atks4.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a3acc
+char const* const s_aassasin_atks3_wav_005a3acc = "aassasin_atks3.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a3ae0
+char const* const s_engineer_atks3_wav_005a3ae0 = "engineer_atks3.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a3af4
+char const* const s_ladder_atks3_wav_005a3af4 = "ladder_atks3.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a3b08
+char const* const s_tunnel_atks3_wav_005a3b08 = "tunnel_atks3.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a3b1c
+char const* const s_monk_atks3_wav_005a3b1c = "monk_atks3.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a3b2c
+char const* const s_knight_atks3_wav_005a3b2c = "knight_atks3.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a3b40
+char const* const s_sword_atks3_wav_005a3b40 = "sword_atks3.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a3b50
+char const* const s_pike_atks3_wav_005a3b50 = "pike_atks3.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a3b60
+char const* const s_mace_atks3_wav_005a3b60 = "mace_atks3.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a3b70
+char const* const s_spear_atks3_wav_005a3b70 = "spear_atks3.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a3b80
+char const* const s_aslave_atks2_wav_005a3b80 = "aslave_atks2.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a3b94
+char const* const s_aassasin_atks2_wav_005a3b94 = "aassasin_atks2.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a3ba8
+char const* const s_engineer_atks2_wav_005a3ba8 = "engineer_atks2.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a3bbc
+char const* const s_ladder_atks2_wav_005a3bbc = "ladder_atks2.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a3bd0
+char const* const s_tunnel_atks2_wav_005a3bd0 = "tunnel_atks2.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a3be4
+char const* const s_monk_atks2_wav_005a3be4 = "monk_atks2.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a3bf4
+char const* const s_knight_atks2_wav_005a3bf4 = "knight_atks2.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a3c08
+char const* const s_sword_atks2_wav_005a3c08 = "sword_atks2.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a3c18
+char const* const s_pike_atks2_wav_005a3c18 = "pike_atks2.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a3c28
+char const* const s_mace_atks2_wav_005a3c28 = "mace_atks2.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a3c38
+char const* const s_spear_atks2_wav_005a3c38 = "spear_atks2.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a3c48
+char const* const s_aslave_atks1_wav_005a3c48 = "aslave_atks1.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a3c5c
+char const* const s_aassasin_atks1_wav_005a3c5c = "aassasin_atks1.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a3c70
+char const* const s_engineer_atks1_wav_005a3c70 = "engineer_atks1.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a3c84
+char const* const s_ladder_atks1_wav_005a3c84 = "ladder_atks1.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a3c98
+char const* const s_tunnel_atks1_wav_005a3c98 = "tunnel_atks1.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a3cac
+char const* const s_monk_atks1_wav_005a3cac = "monk_atks1.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a3cbc
+char const* const s_knight_atks1_wav_005a3cbc = "knight_atks1.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a3cd0
+char const* const s_sword_atks1_wav_005a3cd0 = "sword_atks1.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a3ce0
+char const* const s_pike_atks1_wav_005a3ce0 = "pike_atks1.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a3cf0
+char const* const s_mace_atks1_wav_005a3cf0 = "mace_atks1.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a3d00
+char const* const s_spear_atks1_wav_005a3d00 = "spear_atks1.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a3d10
+char const* const s_ahorse_atkh1_wav_005a3d10 = "ahorse_atkh1.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a3d24
+char const* const s_agrenadier_atkh1_wav_005a3d24 = "agrenadier_atkh1.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a3d3c
+char const* const s_asling_atkh1_wav_005a3d3c = "asling_atkh1.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a3d50
+char const* const s_abow_atkh1_wav_005a3d50 = "abow_atkh1.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a3d60
+char const* const s_cross_atkh1_wav_005a3d60 = "cross_atkh1.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a3d70
+char const* const s_arch_atkh1_wav_005a3d70 = "arch_atkh1.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a3d80
+char const* const s_aslave_moat5_wav_005a3d80 = "aslave_moat5.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a3d94
+char const* const s_spear_moat5_wav_005a3d94 = "spear_moat5.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a3da4
+char const* const s_aslave_moat4_wav_005a3da4 = "aslave_moat4.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a3db8
+char const* const s_spear_moat4_wav_005a3db8 = "spear_moat4.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a3dc8
+char const* const s_asword_moat3_wav_005a3dc8 = "asword_moat3.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a3ddc
+char const* const s_aslave_moat3_wav_005a3ddc = "aslave_moat3.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a3df0
+char const* const s_engineer_moat3_wav_005a3df0 = "engineer_moat3.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a3e04
+char const* const s_ladder_moat3_wav_005a3e04 = "ladder_moat3.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a3e18
+char const* const s_tunnel_moat3_wav_005a3e18 = "tunnel_moat3.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a3e2c
+char const* const s_monk_moat3_wav_005a3e2c = "monk_moat3.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a3e3c
+char const* const s_knight_moat3_wav_005a3e3c = "knight_moat3.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a3e50
+char const* const s_sword_moat3_wav_005a3e50 = "sword_moat3.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a3e60
+char const* const s_pike_moat3_wav_005a3e60 = "pike_moat3.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a3e70
+char const* const s_mace_moat3_wav_005a3e70 = "mace_moat3.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a3e80
+char const* const s_spear_moat3_wav_005a3e80 = "spear_moat3.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a3e90
+char const* const s_cross_moat3_wav_005a3e90 = "cross_moat3.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a3ea0
+char const* const s_arch_moat3_wav_005a3ea0 = "arch_moat3.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a3eb0
+char const* const s_asword_moat2_wav_005a3eb0 = "asword_moat2.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a3ec4
+char const* const s_aslave_moat2_wav_005a3ec4 = "aslave_moat2.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a3ed8
+char const* const s_engineer_moat2_wav_005a3ed8 = "engineer_moat2.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a3eec
+char const* const s_ladder_moat2_wav_005a3eec = "ladder_moat2.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a3f00
+char const* const s_tunnel_moat2_wav_005a3f00 = "tunnel_moat2.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a3f14
+char const* const s_monk_moat2_wav_005a3f14 = "monk_moat2.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a3f24
+char const* const s_knight_moat2_wav_005a3f24 = "knight_moat2.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a3f38
+char const* const s_sword_moat2_wav_005a3f38 = "sword_moat2.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a3f48
+char const* const s_pike_moat2_wav_005a3f48 = "pike_moat2.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a3f58
+char const* const s_mace_moat2_wav_005a3f58 = "mace_moat2.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a3f68
+char const* const s_spear_moat2_wav_005a3f68 = "spear_moat2.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a3f78
+char const* const s_cross_moat2_wav_005a3f78 = "cross_moat2.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a3f88
+char const* const s_arch_moat2_wav_005a3f88 = "arch_moat2.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a3f98
+char const* const s_ahorse_moat1_wav_005a3f98 = "ahorse_moat1.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a3fac
+char const* const s_asword_moat1_wav_005a3fac = "asword_moat1.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a3fc0
+char const* const s_agrenadier_moat1_wav_005a3fc0 = "agrenadier_moat1.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a3fd8
+char const* const s_aslave_moat1_wav_005a3fd8 = "aslave_moat1.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a3fec
+char const* const s_aassasin_moat1_wav_005a3fec = "aassasin_moat1.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a4000
+char const* const s_asling_moat1_wav_005a4000 = "asling_moat1.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a4014
+char const* const s_abow_moat1_wav_005a4014 = "abow_moat1.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a4024
+char const* const s_engineer_moat1_wav_005a4024 = "engineer_moat1.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a4038
+char const* const s_ladder_moat1_wav_005a4038 = "ladder_moat1.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a404c
+char const* const s_tunnel_moat1_wav_005a404c = "tunnel_moat1.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a4060
+char const* const s_monk_moat1_wav_005a4060 = "monk_moat1.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a4070
+char const* const s_knight_moat1_wav_005a4070 = "knight_moat1.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a4084
+char const* const s_sword_moat1_wav_005a4084 = "sword_moat1.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a4094
+char const* const s_pike_moat1_wav_005a4094 = "pike_moat1.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a40a4
+char const* const s_mace_moat1_wav_005a40a4 = "mace_moat1.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a40b4
+char const* const s_spear_moat1_wav_005a40b4 = "spear_moat1.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a40c4
+char const* const s_cross_moat1_wav_005a40c4 = "cross_moat1.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a40d4
+char const* const s_arch_moat1_wav_005a40d4 = "arch_moat1.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a40e4
+char const* const s_ahorse_m5_wav_005a40e4 = "ahorse_m5.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a40f4
+char const* const s_asword_m5_wav_005a40f4 = "asword_m5.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a4104
+char const* const s_agrenadier_m5_wav_005a4104 = "agrenadier_m5.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a4118
+char const* const s_aslave_m5_wav_005a4118 = "aslave_m5.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a4128
+char const* const s_aassasin_m5_wav_005a4128 = "aassasin_m5.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a4138
+char const* const s_asling_m5_wav_005a4138 = "asling_m5.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a4148
+char const* const s_abow_m5_wav_005a4148 = "abow_m5.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a4154
+char const* const s_engineer_m5_wav_005a4154 = "engineer_m5.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a4164
+char const* const s_ladder_m5_wav_005a4164 = "ladder_m5.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a4174
+char const* const s_tunnel_m5_wav_005a4174 = "tunnel_m5.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a4184
+char const* const s_monk_m5_wav_005a4184 = "monk_m5.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a4190
+char const* const s_knight_m5_wav_005a4190 = "knight_m5.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a41a0
+char const* const s_sword_m5_wav_005a41a0 = "sword_m5.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a41b0
+char const* const s_pike_m5_wav_005a41b0 = "pike_m5.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a41bc
+char const* const s_mace_m5_wav_005a41bc = "mace_m5.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a41c8
+char const* const s_spear_m5_wav_005a41c8 = "spear_m5.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a41d8
+char const* const s_cross_m5_wav_005a41d8 = "cross_m5.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a41e8
+char const* const s_arch_m5_wav_005a41e8 = "arch_m5.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a41f4
+char const* const s_ahorse_m4_wav_005a41f4 = "ahorse_m4.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a4204
+char const* const s_asword_m4_wav_005a4204 = "asword_m4.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a4214
+char const* const s_agrenadier_m4_wav_005a4214 = "agrenadier_m4.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a4228
+char const* const s_aslave_m4_wav_005a4228 = "aslave_m4.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a4238
+char const* const s_aassasin_m4_wav_005a4238 = "aassasin_m4.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a4248
+char const* const s_asling_m4_wav_005a4248 = "asling_m4.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a4258
+char const* const s_abow_m4_wav_005a4258 = "abow_m4.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a4264
+char const* const s_engineer_m4_wav_005a4264 = "engineer_m4.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a4274
+char const* const s_ladder_m4_wav_005a4274 = "ladder_m4.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a4284
+char const* const s_tunnel_m4_wav_005a4284 = "tunnel_m4.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a4294
+char const* const s_monk_m4_wav_005a4294 = "monk_m4.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a42a0
+char const* const s_knight_m4_wav_005a42a0 = "knight_m4.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a42b0
+char const* const s_sword_m4_wav_005a42b0 = "sword_m4.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a42c0
+char const* const s_pike_m4_wav_005a42c0 = "pike_m4.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a42cc
+char const* const s_mace_m4_wav_005a42cc = "mace_m4.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a42d8
+char const* const s_spear_m4_wav_005a42d8 = "spear_m4.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a42e8
+char const* const s_cross_m4_wav_005a42e8 = "cross_m4.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a42f8
+char const* const s_arch_m4_wav_005a42f8 = "arch_m4.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a4304
+char const* const s_ahorse_m3_wav_005a4304 = "ahorse_m3.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a4314
+char const* const s_asword_m3_wav_005a4314 = "asword_m3.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a4324
+char const* const s_agrenadier_m3_wav_005a4324 = "agrenadier_m3.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a4338
+char const* const s_aassasin_m3_wav_005a4338 = "aassasin_m3.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a4348
+char const* const s_asling_m3_wav_005a4348 = "asling_m3.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a4358
+char const* const s_abow_m3_wav_005a4358 = "abow_m3.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a4364
+char const* const s_engineer_m3_wav_005a4364 = "engineer_m3.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a4374
+char const* const s_ladder_m3_wav_005a4374 = "ladder_m3.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a4384
+char const* const s_tunnel_m3_wav_005a4384 = "tunnel_m3.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a4394
+char const* const s_monk_m3_wav_005a4394 = "monk_m3.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a43a0
+char const* const s_knight_m3_wav_005a43a0 = "knight_m3.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a43b0
+char const* const s_sword_m3_wav_005a43b0 = "sword_m3.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a43c0
+char const* const s_pike_m3_wav_005a43c0 = "pike_m3.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a43cc
+char const* const s_mace_m3_wav_005a43cc = "mace_m3.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a43d8
+char const* const s_spear_m3_wav_005a43d8 = "spear_m3.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a43e8
+char const* const s_cross_m3_wav_005a43e8 = "cross_m3.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a43f8
+char const* const s_arch_m3_wav_005a43f8 = "arch_m3.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a4404
+char const* const s_ahorse_m2_wav_005a4404 = "ahorse_m2.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a4414
+char const* const s_asword_m2_wav_005a4414 = "asword_m2.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a4424
+char const* const s_agrenadier_m2_wav_005a4424 = "agrenadier_m2.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a4438
+char const* const s_aslave_m2_wav_005a4438 = "aslave_m2.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a4448
+char const* const s_aassasin_m2_wav_005a4448 = "aassasin_m2.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a4458
+char const* const s_asling_m2_wav_005a4458 = "asling_m2.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a4468
+char const* const s_abow_m2_wav_005a4468 = "abow_m2.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a4474
+char const* const s_engineer_m2_wav_005a4474 = "engineer_m2.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a4484
+char const* const s_ladder_m2_wav_005a4484 = "ladder_m2.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a4494
+char const* const s_tunnel_m2_wav_005a4494 = "tunnel_m2.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a44a4
+char const* const s_monk_m2_wav_005a44a4 = "monk_m2.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a44b0
+char const* const s_knight_m2_wav_005a44b0 = "knight_m2.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a44c0
+char const* const s_sword_m2_wav_005a44c0 = "sword_m2.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a44d0
+char const* const s_pike_m2_wav_005a44d0 = "pike_m2.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a44dc
+char const* const s_mace_m2_wav_005a44dc = "mace_m2.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a44e8
+char const* const s_spear_m2_wav_005a44e8 = "spear_m2.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a44f8
+char const* const s_cross_m2_wav_005a44f8 = "cross_m2.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a4508
+char const* const s_arch_m2_wav_005a4508 = "arch_m2.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a4514
+char const* const s_ahorse_m1_wav_005a4514 = "ahorse_m1.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a4524
+char const* const s_asword_m1_wav_005a4524 = "asword_m1.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a4534
+char const* const s_agrenadier_m1_wav_005a4534 = "agrenadier_m1.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a4548
+char const* const s_aslave_m1_wav_005a4548 = "aslave_m1.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a4558
+char const* const s_aassasin_m1_wav_005a4558 = "aassasin_m1.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a4568
+char const* const s_asling_m1_wav_005a4568 = "asling_m1.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a4578
+char const* const s_abow_m1_wav_005a4578 = "abow_m1.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a4584
+char const* const s_engineer_m1_wav_005a4584 = "engineer_m1.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a4594
+char const* const s_ladder_m1_wav_005a4594 = "ladder_m1.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a45a4
+char const* const s_tunnel_m1_wav_005a45a4 = "tunnel_m1.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a45b4
+char const* const s_monk_m1_wav_005a45b4 = "monk_m1.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a45c0
+char const* const s_knight_m1_wav_005a45c0 = "knight_m1.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a45d0
+char const* const s_sword_m1_wav_005a45d0 = "sword_m1.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a45e0
+char const* const s_pike_m1_wav_005a45e0 = "pike_m1.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a45ec
+char const* const s_mace_m1_wav_005a45ec = "mace_m1.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a45f8
+char const* const s_spear_m1_wav_005a45f8 = "spear_m1.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a4608
+char const* const s_cross_m1_wav_005a4608 = "cross_m1.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a4618
+char const* const s_arch_m1_wav_005a4618 = "arch_m1.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a4624
+char const* const s_ahorse_s6_wav_005a4624 = "ahorse_s6.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a4634
+char const* const s_asword_s6_wav_005a4634 = "asword_s6.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a4644
+char const* const s_agrenadier_s6_wav_005a4644 = "agrenadier_s6.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a4658
+char const* const s_aassasin_s6_wav_005a4658 = "aassasin_s6.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a4668
+char const* const s_asling_s6_wav_005a4668 = "asling_s6.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a4678
+char const* const s_abow_s6_wav_005a4678 = "abow_s6.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a4684
+char const* const s_engineer_s6_wav_005a4684 = "engineer_s6.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a4694
+char const* const s_ladder_s6_wav_005a4694 = "ladder_s6.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a46a4
+char const* const s_tunnel_s6_wav_005a46a4 = "tunnel_s6.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a46b4
+char const* const s_monk_s6_wav_005a46b4 = "monk_s6.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a46c0
+char const* const s_knight_s6_wav_005a46c0 = "knight_s6.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a46d0
+char const* const s_sword_s6_wav_005a46d0 = "sword_s6.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a46e0
+char const* const s_pike_s6_wav_005a46e0 = "pike_s6.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a46ec
+char const* const s_mace_s6_wav_005a46ec = "mace_s6.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a46f8
+char const* const s_spear_s6_wav_005a46f8 = "spear_s6.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a4708
+char const* const s_cross_s6_wav_005a4708 = "cross_s6.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a4718
+char const* const s_arch_s6_wav_005a4718 = "arch_s6.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a4724
+char const* const s_ahorse_s5_wav_005a4724 = "ahorse_s5.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a4734
+char const* const s_asword_s5_wav_005a4734 = "asword_s5.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a4744
+char const* const s_agrenadier_s5_wav_005a4744 = "agrenadier_s5.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a4758
+char const* const s_aassasin_s5_wav_005a4758 = "aassasin_s5.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a4768
+char const* const s_asling_s5_wav_005a4768 = "asling_s5.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a4778
+char const* const s_abow_s5_wav_005a4778 = "abow_s5.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a4784
+char const* const s_engineer_s5_wav_005a4784 = "engineer_s5.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a4794
+char const* const s_ladder_s5_wav_005a4794 = "ladder_s5.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a47a4
+char const* const s_tunnel_s5_wav_005a47a4 = "tunnel_s5.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a47b4
+char const* const s_monk_s5_wav_005a47b4 = "monk_s5.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a47c0
+char const* const s_knight_s5_wav_005a47c0 = "knight_s5.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a47d0
+char const* const s_sword_s5_wav_005a47d0 = "sword_s5.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a47e0
+char const* const s_pike_s5_wav_005a47e0 = "pike_s5.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a47ec
+char const* const s_mace_s5_wav_005a47ec = "mace_s5.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a47f8
+char const* const s_spear_s5_wav_005a47f8 = "spear_s5.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a4808
+char const* const s_cross_s5_wav_005a4808 = "cross_s5.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a4818
+char const* const s_arch_s5_wav_005a4818 = "arch_s5.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a4824
+char const* const s_ahorse_s4_wav_005a4824 = "ahorse_s4.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a4834
+char const* const s_asword_s4_wav_005a4834 = "asword_s4.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a4844
+char const* const s_agrenadier_s4_wav_005a4844 = "agrenadier_s4.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a4858
+char const* const s_aassasin_s4_wav_005a4858 = "aassasin_s4.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a4868
+char const* const s_asling_s4_wav_005a4868 = "asling_s4.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a4878
+char const* const s_abow_s4_wav_005a4878 = "abow_s4.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a4884
+char const* const s_engineer_s4_wav_005a4884 = "engineer_s4.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a4894
+char const* const s_ladder_s4_wav_005a4894 = "ladder_s4.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a48a4
+char const* const s_tunnel_s4_wav_005a48a4 = "tunnel_s4.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a48b4
+char const* const s_monk_s4_wav_005a48b4 = "monk_s4.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a48c0
+char const* const s_knight_s4_wav_005a48c0 = "knight_s4.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a48d0
+char const* const s_sword_s4_wav_005a48d0 = "sword_s4.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a48e0
+char const* const s_pike_s4_wav_005a48e0 = "pike_s4.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a48ec
+char const* const s_mace_s4_wav_005a48ec = "mace_s4.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a48f8
+char const* const s_spear_s4_wav_005a48f8 = "spear_s4.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a4908
+char const* const s_cross_s4_wav_005a4908 = "cross_s4.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a4918
+char const* const s_arch_s4_wav_005a4918 = "arch_s4.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a4924
+char const* const s_ahorse_s3_wav_005a4924 = "ahorse_s3.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a4934
+char const* const s_asword_s3_wav_005a4934 = "asword_s3.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a4944
+char const* const s_agrenadier_s3_wav_005a4944 = "agrenadier_s3.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a4958
+char const* const s_aassasin_s3_wav_005a4958 = "aassasin_s3.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a4968
+char const* const s_asling_s3_wav_005a4968 = "asling_s3.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a4978
+char const* const s_abow_s3_wav_005a4978 = "abow_s3.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a4984
+char const* const s_engineer_s3_wav_005a4984 = "engineer_s3.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a4994
+char const* const s_ladder_s3_wav_005a4994 = "ladder_s3.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a49a4
+char const* const s_tunnel_s3_wav_005a49a4 = "tunnel_s3.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a49b4
+char const* const s_monk_s3_wav_005a49b4 = "monk_s3.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a49c0
+char const* const s_knight_s3_wav_005a49c0 = "knight_s3.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a49d0
+char const* const s_sword_s3_wav_005a49d0 = "sword_s3.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a49e0
+char const* const s_pike_s3_wav_005a49e0 = "pike_s3.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a49ec
+char const* const s_mace_s3_wav_005a49ec = "mace_s3.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a49f8
+char const* const s_spear_s3_wav_005a49f8 = "spear_s3.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a4a08
+char const* const s_cross_s3_wav_005a4a08 = "cross_s3.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a4a18
+char const* const s_arch_s3_wav_005a4a18 = "arch_s3.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a4a24
+char const* const s_ahorse_s2_wav_005a4a24 = "ahorse_s2.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a4a34
+char const* const s_asword_s2_wav_005a4a34 = "asword_s2.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a4a44
+char const* const s_agrenadier_s2_wav_005a4a44 = "agrenadier_s2.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a4a58
+char const* const s_aslave_s2_wav_005a4a58 = "aslave_s2.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a4a68
+char const* const s_aassasin_s2_wav_005a4a68 = "aassasin_s2.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a4a78
+char const* const s_asling_s2_wav_005a4a78 = "asling_s2.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a4a88
+char const* const s_abow_s2_wav_005a4a88 = "abow_s2.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a4a94
+char const* const s_engineer_s2_wav_005a4a94 = "engineer_s2.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a4aa4
+char const* const s_ladder_s2_wav_005a4aa4 = "ladder_s2.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a4ab4
+char const* const s_tunnel_s2_wav_005a4ab4 = "tunnel_s2.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a4ac4
+char const* const s_monk_s2_wav_005a4ac4 = "monk_s2.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a4ad0
+char const* const s_knight_s2_wav_005a4ad0 = "knight_s2.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a4ae0
+char const* const s_sword_s2_wav_005a4ae0 = "sword_s2.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a4af0
+char const* const s_pike_s2_wav_005a4af0 = "pike_s2.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a4afc
+char const* const s_mace_s2_wav_005a4afc = "mace_s2.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a4b08
+char const* const s_spear_s2_wav_005a4b08 = "spear_s2.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a4b18
+char const* const s_cross_s2_wav_005a4b18 = "cross_s2.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a4b28
+char const* const s_arch_s2_wav_005a4b28 = "arch_s2.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a4b34
+char const* const s_ahorse_s1_wav_005a4b34 = "ahorse_s1.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a4b44
+char const* const s_asword_s1_wav_005a4b44 = "asword_s1.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a4b54
+char const* const s_agrenadier_s1_wav_005a4b54 = "agrenadier_s1.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a4b68
+char const* const s_aslave_s1_wav_005a4b68 = "aslave_s1.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a4b78
+char const* const s_aassasin_s1_wav_005a4b78 = "aassasin_s1.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a4b88
+char const* const s_asling_s1_wav_005a4b88 = "asling_s1.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a4b98
+char const* const s_abow_s1_wav_005a4b98 = "abow_s1.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a4ba4
+char const* const s_engineer_s1_wav_005a4ba4 = "engineer_s1.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a4bb4
+char const* const s_ladder_s1_wav_005a4bb4 = "ladder_s1.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a4bc4
+char const* const s_tunnel_s1_wav_005a4bc4 = "tunnel_s1.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a4bd4
+char const* const s_monk_s1_wav_005a4bd4 = "monk_s1.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a4be0
+char const* const s_knight_s1_wav_005a4be0 = "knight_s1.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a4bf0
+char const* const s_sword_s1_wav_005a4bf0 = "sword_s1.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a4c00
+char const* const s_pike_s1_wav_005a4c00 = "pike_s1.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a4c0c
+char const* const s_mace_s1_wav_005a4c0c = "mace_s1.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a4c18
+char const* const s_spear_s1_wav_005a4c18 = "spear_s1.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a4c28
+char const* const s_cross_s1_wav_005a4c28 = "cross_s1.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a4c38
+char const* const s_arch_s1_wav_005a4c38 = "arch_s1.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a4c44
+char const* const s_fx_birdsloop_02_wav_005a4c44 = "fx\\birdsloop_02.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a4c58
+char const* const s_fx_birdsloop_01_wav_005a4c58 = "fx\\birdsloop_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a4c6c
+char const* const s_fx_streamlp_02_wav_005a4c6c = "fx\\streamlp_02.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a4c80
+char const* const s_fx_waterfalllp_01_wav_005a4c80 = "fx\\waterfalllp_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a4c98
+char const* const s_fx_firelp_1_wav_005a4c98 = "fx\\firelp_1.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a4ca8
+char const* const s_fx_ocean_short3_wav_005a4ca8 = "fx\\ocean_short3.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a4cbc
+char const* const s_fx_ocean_short2_wav_005a4cbc = "fx\\ocean_short2.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a4cd0
+char const* const s_fx_ocean_short1_wav_005a4cd0 = "fx\\ocean_short1.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a4ce4
+char const* const s_fx_gust1_22k_wav_005a4ce4 = "fx\\gust1 22k.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a4cf8
+char const* const s_Null_wav_005a4cf8 = "Null.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a4d04
+char const* const s_fx_wind_short5_wav_005a4d04 = "fx\\wind_short5.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a4d18
+char const* const s_fx_wind_short4wav_005a4d18 = "fx\\wind_short4wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a4d2c
+char const* const s_fx_wind_short3_wav_005a4d2c = "fx\\wind_short3.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a4d40
+char const* const s_fx_wind_short2_wav_005a4d40 = "fx\\wind_short2.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a4d54
+char const* const s_fx_wind_short1_wav_005a4d54 = "fx\\wind_short1.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a4d68
+char const* const s_fx_speech_s_005a4d68 = "fx\\speech\\%s";
+
+// STRING: STRONGHOLDCRUSADER 0x005a4d78
+char const* const s_buildingwreck_01_wav_005a4d78 = "buildingwreck_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a4d90
+char const* const s_general_victory8_wav_005a4d90 = "general_victory8.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a4da8
+char const* const s_general_victory7_wav_005a4da8 = "general_victory7.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a4dc0
+char const* const s_general_victory6_wav_005a4dc0 = "general_victory6.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a4e08
+char const* const s_fx_volume_txt_005a4e08 = "fx\\volume.txt";
+
+// STRING: STRONGHOLDCRUSADER 0x005a4e18
+char const* const s_rb_005a4e18 = "rb";
+
+// STRING: STRONGHOLDCRUSADER 0x005a4e1c
+char const* const s_Genie_41_wav_005a4e1c = "Genie_41.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a4e2c
+char const* const s_Genie_44_wav_005a4e2c = "Genie_44.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a4e3c
+char const* const s_Genie_43_wav_005a4e3c = "Genie_43.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a4e4c
+char const* const s_Genie_42_wav_005a4e4c = "Genie_42.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a4e5c
+char const* const s_Genie_39_wav_005a4e5c = "Genie_39.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a4e6c
+char const* const s_Genie_38_wav_005a4e6c = "Genie_38.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a4e7c
+char const* const s_Genie_37_wav_005a4e7c = "Genie_37.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a4e8c
+char const* const s_Genie_34_wav_005a4e8c = "Genie_34.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a4e9c
+char const* const s_Genie_32_wav_005a4e9c = "Genie_32.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a4eac
+char const* const s_Genie_31_wav_005a4eac = "Genie_31.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a4ebc
+char const* const s_Genie_30_wav_005a4ebc = "Genie_30.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a4ecc
+char const* const s_Genie_29_wav_005a4ecc = "Genie_29.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a4ef4
+char const* const s_Genie_22_wav_005a4ef4 = "Genie_22.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a4f04
+char const* const s_Genie_21_wav_005a4f04 = "Genie_21.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a4f14
+char const* const s_Genie_20_wav_005a4f14 = "Genie_20.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a4f24
+char const* const s_Genie_19_wav_005a4f24 = "Genie_19.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a4f34
+char const* const s_Genie_18_wav_005a4f34 = "Genie_18.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a4f44
+char const* const s_Genie_17_wav_005a4f44 = "Genie_17.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a4f54
+char const* const s_Genie_16_wav_005a4f54 = "Genie_16.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a4f64
+char const* const SFX_YouAreTheGreatestLord = "Genie_15.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a4f74
+char const* const s_Genie_25_wav_005a4f74 = "Genie_25.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a4f84
+char const* const SFX_FeelThePower = "Genie_40.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a4f94
+char const* const s_Genie_45_wav_005a4f94 = "Genie_45.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a4fa4
+char const* const s_campaign_map_england_black_act_005a4fa4 = "campaign_map_england_black.act";
+
+// STRING: STRONGHOLDCRUSADER 0x005a4fc4
+char const* const s_campaign_map_england_yellow_act_005a4fc4 = "campaign_map_england_yellow.act";
+
+// STRING: STRONGHOLDCRUSADER 0x005a4fe4
+char const* const s_campaign_map_england_orange_act_005a4fe4 = "campaign_map_england_orange.act";
+
+// STRING: STRONGHOLDCRUSADER 0x005a5004
+char const* const s_campaign_map_england_red_act_005a5004 = "campaign_map_england_red.act";
+
+// STRING: STRONGHOLDCRUSADER 0x005a5024
+char const* const s_campaign_map_england_blue_act_005a5024 = "campaign_map_england_blue.act";
+
+// STRING: STRONGHOLDCRUSADER 0x005a5044
+char const* const s_campaign_map_england_basic_act_005a5044 = "campaign_map_england_basic.act";
+
+// STRING: STRONGHOLDCRUSADER 0x005a5064
+char const* const s_act_005a5064 = "act";
+
+// STRING: STRONGHOLDCRUSADER 0x005a5068
+char const* const s_gm1_005a5068 = "gm1";
+
+// STRING: STRONGHOLDCRUSADER 0x005a506c
+char const* const s_null_005a506c = "null";
+
+// STRING: STRONGHOLDCRUSADER 0x005a5074
+char const* const s_food_warning3_wav_005a5074 = "food_warning3.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a5088
+char const* const s_food_warning2_wav_005a5088 = "food_warning2.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a509c
+char const* const s_food_warning4_wav_005a509c = "food_warning4.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a50b0
+char const* const s_space_warning5_wav_005a50b0 = "space_warning5.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a50c4
+char const* const s_PdLim__005a50c4 = "PdLim: ";
+
+// STRING: STRONGHOLDCRUSADER 0x005a50cc
+char const* const s_OrLim__005a50cc = "OrLim: ";
+
+// STRING: STRONGHOLDCRUSADER 0x005a50d4
+char const* const s_MoLim__005a50d4 = "MoLim: ";
+
+// STRING: STRONGHOLDCRUSADER 0x005a50dc
+char const* const s_FlLim__005a50dc = "FlLim: ";
+
+// STRING: STRONGHOLDCRUSADER 0x005a50e4
+char const* const s_StLim__005a50e4 = "StLim: ";
+
+// STRING: STRONGHOLDCRUSADER 0x005a50ec
+char const* const s_ChLim__005a50ec = "ChLim: ";
+
+// STRING: STRONGHOLDCRUSADER 0x005a50f4
+char const* const s_Troops__005a50f4 = "Troops: ";
+
+// STRING: STRONGHOLDCRUSADER 0x005a5100
+char const* const s_Enemy_hit__005a5100 = "Enemy hit: ";
+
+// STRING: STRONGHOLDCRUSADER 0x005a510c
+char const* const s_Mini_spreads__005a510c = "Mini spreads: ";
+
+// STRING: STRONGHOLDCRUSADER 0x005a511c
+char const* const s_Spreads__005a511c = "Spreads: ";
+
+// STRING: STRONGHOLDCRUSADER 0x005a5128
+char const* const s_Test_gatehouse__005a5128 = "Test gatehouse.. ";
+
+// STRING: STRONGHOLDCRUSADER 0x005a513c
+char const* const s_Test_likely__005a513c = "Test likely.. ";
+
+// STRING: STRONGHOLDCRUSADER 0x005a514c
+char const* const s_1Wys__005a514c = "1Wys: ";
+
+// STRING: STRONGHOLDCRUSADER 0x005a5154
+char const* const s_Ass__005a5154 = "Ass:";
+
+// STRING: STRONGHOLDCRUSADER 0x005a515c
+char const* const s_Xm__005a515c = "Xm:";
+
+// STRING: STRONGHOLDCRUSADER 0x005a5160
+char const* const s_Hard__005a5160 = "Hard: ";
+
+// STRING: STRONGHOLDCRUSADER 0x005a5168
+char const* const s_Easy__005a5168 = "Easy: ";
+
+// STRING: STRONGHOLDCRUSADER 0x005a5170
+char const* const s_Fires_005a5170 = "Fires ";
+
+// STRING: STRONGHOLDCRUSADER 0x005a5178
+char const* const s_gate_links_005a5178 = "gate links ";
+
+// STRING: STRONGHOLDCRUSADER 0x005a5184
+char const* const s_Moat_tiles_005a5184 = "Moat tiles";
+
+// STRING: STRONGHOLDCRUSADER 0x005a5190
+char const* const s_skipped_isos_005a5190 = "skipped isos";
+
+// STRING: STRONGHOLDCRUSADER 0x005a51a0
+char const* const s_fcn_mtribe_005a51a0 = "fcn mtribe";
+
+// STRING: STRONGHOLDCRUSADER 0x005a51ac
+char const* const s_Ale_rate_005a51ac = "Ale rate ";
+
+// STRING: STRONGHOLDCRUSADER 0x005a51b8
+char const* const s_lord_killed_005a51b8 = "lord killed ";
+
+// STRING: STRONGHOLDCRUSADER 0x005a51c8
+char const* const s_vclock_005a51c8 = "vclock";
+
+// STRING: STRONGHOLDCRUSADER 0x005a51d0
+char const* const s_capacity_005a51d0 = "capacity";
+
+// STRING: STRONGHOLDCRUSADER 0x005a51dc
+char const* const s_crowding_005a51dc = "crowding";
+
+// STRING: STRONGHOLDCRUSADER 0x005a51e8
+char const* const s_popular__005a51e8 = "popular:";
+
+// STRING: STRONGHOLDCRUSADER 0x005a51f4
+char const* const s_enemies_005a51f4 = "enemies ";
+
+// STRING: STRONGHOLDCRUSADER 0x005a5200
+char const* const s_power_005a5200 = "power ";
+
+// STRING: STRONGHOLDCRUSADER 0x005a5208
+char const* const s_lightning_count_005a5208 = "lightning count";
+
+// STRING: STRONGHOLDCRUSADER 0x005a5218
+char const* const s_last_food_005a5218 = "last food ";
+
+// STRING: STRONGHOLDCRUSADER 0x005a5224
+char const* const s_Pop_005a5224 = "Pop ";
+
+// STRING: STRONGHOLDCRUSADER 0x005a522c
+char const* const s_Total_chimps_005a522c = "Total chimps ";
+
+// STRING: STRONGHOLDCRUSADER 0x005a523c
+char const* const s_CRC_005a523c = "CRC ";
+
+// STRING: STRONGHOLDCRUSADER 0x005a5244
+char const* const s_new_organisms_005a5244 = "new organisms ";
+
+// STRING: STRONGHOLDCRUSADER 0x005a5254
+char const* const s_Total_organisms_005a5254 = "Total organisms ";
+
+// STRING: STRONGHOLDCRUSADER 0x005a5268
+char const* const s_player_005a5268 = "player ";
+
+// STRING: STRONGHOLDCRUSADER 0x005a5270
+char const* const s_LIGHTBLUE_005a5270 = "LIGHTBLUE";
+
+// STRING: STRONGHOLDCRUSADER 0x005a527c
+char const* const s_DARKORANGE_005a527c = "DARKORANGE";
+
+// STRING: STRONGHOLDCRUSADER 0x005a5288
+char const* const s_LIGHTORANGE_005a5288 = "LIGHTORANGE";
+
+// STRING: STRONGHOLDCRUSADER 0x005a5294
+char const* const s_ORANGE_005a5294 = "ORANGE";
+
+// STRING: STRONGHOLDCRUSADER 0x005a529c
+char const* const s_GREY_005a529c = "GREY";
+
+// STRING: STRONGHOLDCRUSADER 0x005a52a4
+char const* const s_CYAN_005a52a4 = "CYAN";
+
+// STRING: STRONGHOLDCRUSADER 0x005a52ac
+char const* const s_YELLOW_005a52ac = "YELLOW";
+
+// STRING: STRONGHOLDCRUSADER 0x005a52b4
+char const* const s_GREEN_005a52b4 = "GREEN";
+
+// STRING: STRONGHOLDCRUSADER 0x005a52bc
+char const* const s_BLUE_005a52bc = "BLUE";
+
+// STRING: STRONGHOLDCRUSADER 0x005a52c4
+char const* const s_RED_005a52c4 = "RED";
+
+// STRING: STRONGHOLDCRUSADER 0x005a52c8
+char const* const s_WHITE_005a52c8 = "WHITE";
+
+// STRING: STRONGHOLDCRUSADER 0x005a52d0
+char const* const s_BLACK_005a52d0 = "BLACK";
+
+// STRING: STRONGHOLDCRUSADER 0x005a52d8
+char const* const s_Stronghold_44_aa_005a52d8 = "Stronghold 44 aa";
+
+// STRING: STRONGHOLDCRUSADER 0x005a52ec
+char const* const s_Stronghold_30_aa_005a52ec = "Stronghold 30 aa";
+
+// STRING: STRONGHOLDCRUSADER 0x005a5300
+char const* const s_Stronghold_24_aa_005a5300 = "Stronghold 24 aa";
+
+// STRING: STRONGHOLDCRUSADER 0x005a5314
+char const* const s_Stronghold_16_aa_005a5314 = "Stronghold 16 aa";
+
+// STRING: STRONGHOLDCRUSADER 0x005a5328
+char const* const s_Stronghold_14_aa_005a5328 = "Stronghold 14 aa";
+
+// STRING: STRONGHOLDCRUSADER 0x005a5510
+char const* const s_wb_005a5510 = "wb";
+
+// STRING: STRONGHOLDCRUSADER 0x005a5514
+char const* const s_Here_005a5514 = "Here";
+
+// STRING: STRONGHOLDCRUSADER 0x005a551c
+char const* const s_Right_005a551c = "Right";
+
+// STRING: STRONGHOLDCRUSADER 0x005a5524
+char const* const s_NEXT_005a5524 = "NEXT";
+
+// STRING: STRONGHOLDCRUSADER 0x005a552c
+char const* const s_PREV_005a552c = "PREV";
+
+// STRING: STRONGHOLDCRUSADER 0x005a5534
+char const* const s_Left_005a5534 = "Left";
+
+// STRING: STRONGHOLDCRUSADER 0x005a553c
+char const* const s_INCLUDE_005a553c = "INCLUDE";
+
+// STRING: STRONGHOLDCRUSADER 0x005a5544
+char const* const s_STRING_005a5544 = "STRING";
+
+// STRING: STRONGHOLDCRUSADER 0x005a554c
+char const* const s_SOUND_005a554c = "SOUND";
+
+// STRING: STRONGHOLDCRUSADER 0x005a5554
+char const* const s__CENTRE_005a5554 = "\\CENTRE";
+
+// STRING: STRONGHOLDCRUSADER 0x005a555c
+char const* const s_CENTRE_005a555c = "CENTRE";
+
+// STRING: STRONGHOLDCRUSADER 0x005a5564
+char const* const s__LINK_005a5564 = "\\LINK";
+
+// STRING: STRONGHOLDCRUSADER 0x005a556c
+char const* const s_LINK_005a556c = "LINK";
+
+// STRING: STRONGHOLDCRUSADER 0x005a5574
+char const* const s_LINKCLR_005a5574 = "LINKCLR";
+
+// STRING: STRONGHOLDCRUSADER 0x005a557c
+char const* const s_COLOUR_005a557c = "COLOUR";
+
+// STRING: STRONGHOLDCRUSADER 0x005a5584
+char const* const s_FONT_005a5584 = "FONT";
+
+// STRING: STRONGHOLDCRUSADER 0x005a558c
+char const* const s_PIC_005a558c = "PIC";
+
+// STRING: STRONGHOLDCRUSADER 0x005a5590
+char const* const s_Include_005a5590 = "Include";
+
+// STRING: STRONGHOLDCRUSADER 0x005a5598
+char const* const s_String_005a5598 = "String";
+
+// STRING: STRONGHOLDCRUSADER 0x005a55a0
+char const* const s_Sound_005a55a0 = "Sound";
+
+// STRING: STRONGHOLDCRUSADER 0x005a55a8
+char const* const s_LinkClr_005a55a8 = "LinkClr";
+
+// STRING: STRONGHOLDCRUSADER 0x005a55b0
+char const* const s_Colour_005a55b0 = "Colour";
+
+// STRING: STRONGHOLDCRUSADER 0x005a55b8
+char const* const s__Centre_005a55b8 = "\\Centre";
+
+// STRING: STRONGHOLDCRUSADER 0x005a55c0
+char const* const s_Centre_005a55c0 = "Centre";
+
+// STRING: STRONGHOLDCRUSADER 0x005a55c8
+char const* const s_Font_005a55c8 = "Font";
+
+// STRING: STRONGHOLDCRUSADER 0x005a55d0
+char const* const s__Link_005a55d0 = "\\Link";
+
+// STRING: STRONGHOLDCRUSADER 0x005a55d8
+char const* const s_Link_005a55d8 = "Link";
+
+// STRING: STRONGHOLDCRUSADER 0x005a55e4
+char const* const s_ScrSize_005a55e4 = "ScrSize";
+
+// STRING: STRONGHOLDCRUSADER 0x005a55ec
+char const* const s_Save_005a55ec = "Save";
+
+// STRING: STRONGHOLDCRUSADER 0x005a55f4
+char const* const s_Load_005a55f4 = "Load";
+
+// STRING: STRONGHOLDCRUSADER 0x005a55fc
+char const* const s_New_Page_005a55fc = "New Page";
+
+// STRING: STRONGHOLDCRUSADER 0x005a5608
+char const* const s_Symbols_005a5608 = "Symbols";
+
+// STRING: STRONGHOLDCRUSADER 0x005a5620
+char const* const s_crusader_help_hlp_005a5620 = "crusader_help.hlp";
+
+// STRING: STRONGHOLDCRUSADER 0x005a5728
+char const* const s_st99_dog_cage_tgx_005a5728 = "st99_dog_cage.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005a585c
+char const* const s_Select_help_file_to_include_005a585c = "Select help file to include";
+
+// STRING: STRONGHOLDCRUSADER 0x005a5878
+char const* const s_Select_help_file_to_link_to_005a5878 = "Select help file to link to";
+
+// STRING: STRONGHOLDCRUSADER 0x005a5894
+char const* const s_Select_help_file_to_load_005a5894 = "Select help file to load";
+
+// STRING: STRONGHOLDCRUSADER 0x005a58b0
+char const* const s_other_warning7_wav_005a58b0 = "other_warning7.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a58c4
+char const* const s_other_warning5_wav_005a58c4 = "other_warning5.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a58d8
+char const* const s_units_warning3_wav_005a58d8 = "units_warning3.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a58ec
+char const* const s_space_warning7_wav_005a58ec = "space_warning7.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a5900
+char const* const s_space_warning6_wav_005a5900 = "space_warning6.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a5914
+char const* const s_space_warning4_wav_005a5914 = "space_warning4.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a5928
+char const* const s_space_warning3_wav_005a5928 = "space_warning3.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a593c
+char const* const s_space_warning1_wav_005a593c = "space_warning1.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a5950
+char const* const s_space_warning2_wav_005a5950 = "space_warning2.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a5964
+char const* const s_space_warning8_wav_005a5964 = "space_warning8.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a5978
+char const* const s_other_warning6_wav_005a5978 = "other_warning6.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a598c
+char const* const s_Genie_26_wav_005a598c = "Genie_26.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a599c
+char const* const s_Genie_27_wav_005a599c = "Genie_27.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a59c8
+char const* const s_FFwinClass_005a59c8 = "FFwinClass";
+
+// STRING: STRONGHOLDCRUSADER 0x005a59d4
+char const* const s_1181_005a59d4 = "1181";
+
+// STRING: STRONGHOLDCRUSADER 0x005a59dc
+char const* const s_Game_load_string_005a59dc = "Game load string";
+
+// STRING: STRONGHOLDCRUSADER 0x005a59f0
+char const* const s_Campaign_name_string_005a59f0 = "Campaign name string";
+
+// STRING: STRONGHOLDCRUSADER 0x005a5a08
+char const* const s__s_005a5a08 = "%s ";
+
+// STRING: STRONGHOLDCRUSADER 0x005a5a0c
+char const* const s_configpath_txt_005a5a0c = "configpath.txt";
+
+// STRING: STRONGHOLDCRUSADER 0x005a5a1c
+char const* const s_gfx__005a5a1c = "gfx\\";
+
+// STRING: STRONGHOLDCRUSADER 0x005a5a24
+char const* const s_help__005a5a24 = "help\\";
+
+// STRING: STRONGHOLDCRUSADER 0x005a5a2c
+char const* const s_fx__005a5a2c = "fx\\";
+
+// STRING: STRONGHOLDCRUSADER 0x005a5a48
+char const* const s_Wide_Open_Plain_005a5a48 = "Wide_Open_Plain";
+
+// STRING: STRONGHOLDCRUSADER 0x005a5a58
+char const* const s_Wazirs_Fortress_005a5a58 = "Wazirs_Fortress";
+
+// STRING: STRONGHOLDCRUSADER 0x005a5a68
+char const* const s_Ultimate_Victory_005a5a68 = "Ultimate_Victory";
+
+// STRING: STRONGHOLDCRUSADER 0x005a5a7c
+char const* const s_Three_Little_Pigs_005a5a7c = "Three_Little_Pigs";
+
+// STRING: STRONGHOLDCRUSADER 0x005a5a90
+char const* const s_The_Host_005a5a90 = "The_Host";
+
+// STRING: STRONGHOLDCRUSADER 0x005a5a9c
+char const* const s_Swampy_Island_005a5a9c = "Swampy_Island";
+
+// STRING: STRONGHOLDCRUSADER 0x005a5aac
+char const* const s_Spider_Island_005a5aac = "Spider_Island";
+
+// STRING: STRONGHOLDCRUSADER 0x005a5abc
+char const* const s_Snake_River_005a5abc = "Snake_River";
+
+// STRING: STRONGHOLDCRUSADER 0x005a5ac8
+char const* const s_Rivers_Fork_005a5ac8 = "Rivers_Fork";
+
+// STRING: STRONGHOLDCRUSADER 0x005a5ad4
+char const* const s_Phoenix_005a5ad4 = "Phoenix";
+
+// STRING: STRONGHOLDCRUSADER 0x005a5adc
+char const* const s_MP_Valley_of_the_Lords_005a5adc = "MP-Valley of the Lords";
+
+// STRING: STRONGHOLDCRUSADER 0x005a5af4
+char const* const s_MP_Two_Falls_005a5af4 = "MP-Two Falls";
+
+// STRING: STRONGHOLDCRUSADER 0x005a5b04
+char const* const s_MP_The_Rocky_Divide_005a5b04 = "MP-The Rocky Divide";
+
+// STRING: STRONGHOLDCRUSADER 0x005a5b18
+char const* const s_MP_Surrounded_005a5b18 = "MP-Surrounded";
+
+// STRING: STRONGHOLDCRUSADER 0x005a5b28
+char const* const s_MP_Snake_River_005a5b28 = "MP-Snake River";
+
+// STRING: STRONGHOLDCRUSADER 0x005a5b38
+char const* const s_MP_Slopes_of_Doom_005a5b38 = "MP-Slopes of Doom";
+
+// STRING: STRONGHOLDCRUSADER 0x005a5b4c
+char const* const s_MP_No_Where_to_Hide_005a5b4c = "MP-No Where to Hide";
+
+// STRING: STRONGHOLDCRUSADER 0x005a5b60
+char const* const s_MP_No_Mans_Land_005a5b60 = "MP-No Mans Land";
+
+// STRING: STRONGHOLDCRUSADER 0x005a5b70
+char const* const s_MP_Downhill_Scrum_005a5b70 = "MP-Downhill Scrum";
+
+// STRING: STRONGHOLDCRUSADER 0x005a5b84
+char const* const s_MP_Divided_005a5b84 = "MP-Divided";
+
+// STRING: STRONGHOLDCRUSADER 0x005a5b90
+char const* const s_Look_Out_005a5b90 = "Look_Out";
+
+// STRING: STRONGHOLDCRUSADER 0x005a5b9c
+char const* const s_Lionheart_005a5b9c = "Lionheart";
+
+// STRING: STRONGHOLDCRUSADER 0x005a5ba8
+char const* const s_Jealous_Neighbours_005a5ba8 = "Jealous_Neighbours";
+
+// STRING: STRONGHOLDCRUSADER 0x005a5bbc
+char const* const s_Fury_Bay_005a5bbc = "Fury_Bay";
+
+// STRING: STRONGHOLDCRUSADER 0x005a5bc8
+char const* const s_Enclosure_005a5bc8 = "Enclosure";
+
+// STRING: STRONGHOLDCRUSADER 0x005a5bd4
+char const* const s_Divided_005a5bd4 = "Divided";
+
+// STRING: STRONGHOLDCRUSADER 0x005a5bdc
+char const* const s_Crossroads_005a5bdc = "Crossroads";
+
+// STRING: STRONGHOLDCRUSADER 0x005a5be8
+char const* const s_Coastal_Trap_005a5be8 = "Coastal_Trap";
+
+// STRING: STRONGHOLDCRUSADER 0x005a5bf8
+char const* const s_Bird_In_Flight_005a5bf8 = "Bird_In_Flight";
+
+// STRING: STRONGHOLDCRUSADER 0x005a5c08
+char const* const s_Best_Friends_005a5c08 = "Best_Friends";
+
+// STRING: STRONGHOLDCRUSADER 0x005a5c18
+char const* const s_Wall_of_Iron_005a5c18 = "Wall of Iron";
+
+// STRING: STRONGHOLDCRUSADER 0x005a5c28
+char const* const s_Watering_Holes_005a5c28 = "Watering Holes";
+
+// STRING: STRONGHOLDCRUSADER 0x005a5c38
+char const* const s_West_Coast_005a5c38 = "West Coast";
+
+// STRING: STRONGHOLDCRUSADER 0x005a5c44
+char const* const s_Upwards_Alliance_005a5c44 = "Upwards Alliance";
+
+// STRING: STRONGHOLDCRUSADER 0x005a5c58
+char const* const s_Two_in_a_bed_005a5c58 = "Two in a bed";
+
+// STRING: STRONGHOLDCRUSADER 0x005a5c68
+char const* const s_Tilos_005a5c68 = "Tilos";
+
+// STRING: STRONGHOLDCRUSADER 0x005a5c70
+char const* const s_The_Dunes_005a5c70 = "The Dunes";
+
+// STRING: STRONGHOLDCRUSADER 0x005a5c7c
+char const* const s_The_Wet_Lands_005a5c7c = "The Wet Lands";
+
+// STRING: STRONGHOLDCRUSADER 0x005a5c8c
+char const* const s_The_Trench_005a5c8c = "The Trench";
+
+// STRING: STRONGHOLDCRUSADER 0x005a5c98
+char const* const s_The_River_005a5c98 = "The River";
+
+// STRING: STRONGHOLDCRUSADER 0x005a5ca4
+char const* const s_The_Last_Stand_005a5ca4 = "The Last Stand";
+
+// STRING: STRONGHOLDCRUSADER 0x005a5cb4
+char const* const s_The_Killing_Plains_005a5cb4 = "The Killing Plains";
+
+// STRING: STRONGHOLDCRUSADER 0x005a5cc8
+char const* const s_The_Guardians_005a5cc8 = "The Guardians";
+
+// STRING: STRONGHOLDCRUSADER 0x005a5cd8
+char const* const s_The_Great_lake_005a5cd8 = "The Great lake";
+
+// STRING: STRONGHOLDCRUSADER 0x005a5ce8
+char const* const s_The_Forest_Oasis_005a5ce8 = "The Forest Oasis";
+
+// STRING: STRONGHOLDCRUSADER 0x005a5cfc
+char const* const s_The_ford_across_the_river_005a5cfc = "The ford across the river";
+
+// STRING: STRONGHOLDCRUSADER 0x005a5d18
+char const* const s_Trapesac_Island_005a5d18 = "Trapesac Island";
+
+// STRING: STRONGHOLDCRUSADER 0x005a5d28
+char const* const s_Target_Zone_005a5d28 = "Target Zone";
+
+// STRING: STRONGHOLDCRUSADER 0x005a5d34
+char const* const s_Too_Close_For_Comfort_005a5d34 = "Too Close For Comfort";
+
+// STRING: STRONGHOLDCRUSADER 0x005a5d4c
+char const* const s_The_Bulls_Eye_005a5d4c = "The Bulls Eye";
+
+// STRING: STRONGHOLDCRUSADER 0x005a5d5c
+char const* const s_The_Valley_005a5d5c = "The Valley";
+
+// STRING: STRONGHOLDCRUSADER 0x005a5d68
+char const* const s_Thasos_005a5d68 = "Thasos";
+
+// STRING: STRONGHOLDCRUSADER 0x005a5d70
+char const* const s_Tripoli_005a5d70 = "Tripoli";
+
+// STRING: STRONGHOLDCRUSADER 0x005a5d78
+char const* const s_Tyre_005a5d78 = "Tyre";
+
+// STRING: STRONGHOLDCRUSADER 0x005a5d80
+char const* const s_Small_Island_005a5d80 = "Small Island";
+
+// STRING: STRONGHOLDCRUSADER 0x005a5d90
+char const* const s_Small_Barren_Desert_005a5d90 = "Small Barren Desert";
+
+// STRING: STRONGHOLDCRUSADER 0x005a5da4
+char const* const s_Strati_005a5da4 = "Strati";
+
+// STRING: STRONGHOLDCRUSADER 0x005a5dac
+char const* const s_Sleeping_With_The_Enemy_005a5dac = "Sleeping With The Enemy";
+
+// STRING: STRONGHOLDCRUSADER 0x005a5dc4
+char const* const s_Rock_Face_005a5dc4 = "Rock Face";
+
+// STRING: STRONGHOLDCRUSADER 0x005a5dd0
+char const* const s_Region_of_Corinth_005a5dd0 = "Region of Corinth";
+
+// STRING: STRONGHOLDCRUSADER 0x005a5de4
+char const* const s_Reed_Sea_005a5de4 = "Reed Sea";
+
+// STRING: STRONGHOLDCRUSADER 0x005a5df0
+char const* const s_Rocky_Oasis_005a5df0 = "Rocky Oasis";
+
+// STRING: STRONGHOLDCRUSADER 0x005a5dfc
+char const* const s_Riverside_Rampage_005a5dfc = "Riverside Rampage";
+
+// STRING: STRONGHOLDCRUSADER 0x005a5e10
+char const* const s_Province_of_Bodrum_005a5e10 = "Province of Bodrum";
+
+// STRING: STRONGHOLDCRUSADER 0x005a5e24
+char const* const s_Pig_in_a_Poke_005a5e24 = "Pig in a Poke";
+
+// STRING: STRONGHOLDCRUSADER 0x005a5e34
+char const* const s_Piggy_in_the_middle_005a5e34 = "Piggy in the middle";
+
+// STRING: STRONGHOLDCRUSADER 0x005a5e48
+char const* const s_Oasis_by_the_Sea_005a5e48 = "Oasis by the Sea";
+
+// STRING: STRONGHOLDCRUSADER 0x005a5e5c
+char const* const s_Oasis_Struggle_005a5e5c = "Oasis Struggle";
+
+// STRING: STRONGHOLDCRUSADER 0x005a5e6c
+char const* const s_Melos_005a5e6c = "Melos";
+
+// STRING: STRONGHOLDCRUSADER 0x005a5e74
+char const* const s_Marshy_Mayhem_005a5e74 = "Marshy Mayhem";
+
+// STRING: STRONGHOLDCRUSADER 0x005a5e84
+char const* const s_North_vs_South_005a5e84 = "North vs South";
+
+// STRING: STRONGHOLDCRUSADER 0x005a5e94
+char const* const s_No_Escape_005a5e94 = "No Escape";
+
+// STRING: STRONGHOLDCRUSADER 0x005a5ea0
+char const* const s_Litani_and_Jordan_005a5ea0 = "Litani and Jordan";
+
+// STRING: STRONGHOLDCRUSADER 0x005a5eb4
+char const* const s_Lake_Qaddas_005a5eb4 = "Lake Qaddas";
+
+// STRING: STRONGHOLDCRUSADER 0x005a5ec0
+char const* const s_Lakes_of_Konya_005a5ec0 = "Lakes of Konya";
+
+// STRING: STRONGHOLDCRUSADER 0x005a5ed0
+char const* const s_Lacus_Magnus_005a5ed0 = "Lacus Magnus";
+
+// STRING: STRONGHOLDCRUSADER 0x005a5ee0
+char const* const s_Land_of_the_Cactus_005a5ee0 = "Land of the Cactus";
+
+// STRING: STRONGHOLDCRUSADER 0x005a5ef4
+char const* const s_Large_Island_005a5ef4 = "Large Island";
+
+// STRING: STRONGHOLDCRUSADER 0x005a5f04
+char const* const s_Large_Barren_Desert_005a5f04 = "Large Barren Desert";
+
+// STRING: STRONGHOLDCRUSADER 0x005a5f18
+char const* const s_Love_Thy_Neighbour_005a5f18 = "Love Thy Neighbour";
+
+// STRING: STRONGHOLDCRUSADER 0x005a5f2c
+char const* const s_Its_just_not_fair_005a5f2c = "Its just not fair";
+
+// STRING: STRONGHOLDCRUSADER 0x005a5f40
+char const* const s_In_The_Shadow_005a5f40 = "In The Shadow";
+
+// STRING: STRONGHOLDCRUSADER 0x005a5f50
+char const* const s_In_The_canyons_005a5f50 = "In The canyons";
+
+// STRING: STRONGHOLDCRUSADER 0x005a5f60
+char const* const s_Its_a_jungle_out_there_005a5f60 = "Its a jungle out there";
+
+// STRING: STRONGHOLDCRUSADER 0x005a5f78
+char const* const s_Island_Hoppin_005a5f78 = "Island Hoppin";
+
+// STRING: STRONGHOLDCRUSADER 0x005a5f88
+char const* const s_Inches_Apart_005a5f88 = "Inches Apart";
+
+// STRING: STRONGHOLDCRUSADER 0x005a5f98
+char const* const s_Hidden_Crater_005a5f98 = "Hidden Crater";
+
+// STRING: STRONGHOLDCRUSADER 0x005a5fa8
+char const* const s_Hills_of_Antioch_005a5fa8 = "Hills of Antioch";
+
+// STRING: STRONGHOLDCRUSADER 0x005a5fbc
+char const* const s_Halys_River_005a5fbc = "Halys River";
+
+// STRING: STRONGHOLDCRUSADER 0x005a5fc8
+char const* const s_Hilltop_Hideout_005a5fc8 = "Hilltop Hideout";
+
+// STRING: STRONGHOLDCRUSADER 0x005a5fd8
+char const* const s_Hell_On_The_Hill_005a5fd8 = "Hell On The Hill";
+
+// STRING: STRONGHOLDCRUSADER 0x005a5fec
+char const* const s_Height_Advantage_005a5fec = "Height Advantage";
+
+// STRING: STRONGHOLDCRUSADER 0x005a6000
+char const* const s_Happy_Land_005a6000 = "Happy Land";
+
+// STRING: STRONGHOLDCRUSADER 0x005a600c
+char const* const s_Great_Euphrates_005a600c = "Great Euphrates";
+
+// STRING: STRONGHOLDCRUSADER 0x005a601c
+char const* const s_Green_Haven_005a601c = "Green Haven";
+
+// STRING: STRONGHOLDCRUSADER 0x005a6028
+char const* const s_Green_Belt_005a6028 = "Green Belt";
+
+// STRING: STRONGHOLDCRUSADER 0x005a6034
+char const* const s_Flood_Plains_of_Jordan_005a6034 = "Flood Plains of Jordan";
+
+// STRING: STRONGHOLDCRUSADER 0x005a604c
+char const* const s_Edessa_005a604c = "Edessa";
+
+// STRING: STRONGHOLDCRUSADER 0x005a6054
+char const* const s_Empty_Handed_005a6054 = "Empty Handed";
+
+// STRING: STRONGHOLDCRUSADER 0x005a6064
+char const* const s_Dunes_of_Nicaea_005a6064 = "Dunes of Nicaea";
+
+// STRING: STRONGHOLDCRUSADER 0x005a6074
+char const* const s_Drawn_and_Quartered_005a6074 = "Drawn and Quartered";
+
+// STRING: STRONGHOLDCRUSADER 0x005a6088
+char const* const s_Desert_Island_Blues_005a6088 = "Desert Island Blues";
+
+// STRING: STRONGHOLDCRUSADER 0x005a609c
+char const* const s_Craggy_Cliffs_005a609c = "Craggy Cliffs";
+
+// STRING: STRONGHOLDCRUSADER 0x005a60ac
+char const* const s_Coconut_Twist_005a60ac = "Coconut Twist";
+
+// STRING: STRONGHOLDCRUSADER 0x005a60bc
+char const* const s_Caesarea_Swampland_005a60bc = "Caesarea Swampland";
+
+// STRING: STRONGHOLDCRUSADER 0x005a60d0
+char const* const s_Cyclades_005a60d0 = "Cyclades";
+
+// STRING: STRONGHOLDCRUSADER 0x005a60dc
+char const* const s_Crusader_Demo_005a60dc = "Crusader Demo";
+
+// STRING: STRONGHOLDCRUSADER 0x005a60ec
+char const* const s_Canyons_005a60ec = "Canyons";
+
+// STRING: STRONGHOLDCRUSADER 0x005a60f4
+char const* const s_Cactus_Valley_005a60f4 = "Cactus Valley";
+
+// STRING: STRONGHOLDCRUSADER 0x005a6104
+char const* const s_Crete_Peninsula_005a6104 = "Crete Peninsula";
+
+// STRING: STRONGHOLDCRUSADER 0x005a6114
+char const* const s_Close_Encounters_005a6114 = "Close Encounters";
+
+// STRING: STRONGHOLDCRUSADER 0x005a6128
+char const* const s_Centre_of_the_Oasis_005a6128 = "Centre of the Oasis";
+
+// STRING: STRONGHOLDCRUSADER 0x005a613c
+char const* const s_Broken_Dune_005a613c = "Broken Dune";
+
+// STRING: STRONGHOLDCRUSADER 0x005a6148
+char const* const s_Bow_Ridge_005a6148 = "Bow Ridge";
+
+// STRING: STRONGHOLDCRUSADER 0x005a6154
+char const* const s_Border_Patrol_005a6154 = "Border Patrol";
+
+// STRING: STRONGHOLDCRUSADER 0x005a6164
+char const* const s_Arnon_River_005a6164 = "Arnon River";
+
+// STRING: STRONGHOLDCRUSADER 0x005a6170
+char const* const s_Armenia_005a6170 = "Armenia";
+
+// STRING: STRONGHOLDCRUSADER 0x005a6178
+char const* const s_A_Mighty_Oasis_005a6178 = "A Mighty Oasis";
+
+// STRING: STRONGHOLDCRUSADER 0x005a6188
+char const* const s_Antioch_005a6188 = "Antioch";
+
+// STRING: STRONGHOLDCRUSADER 0x005a6190
+char const* const s_A_Friend_Indeed_005a6190 = "A Friend Indeed";
+
+// STRING: STRONGHOLDCRUSADER 0x005a61a0
+char const* const s_A_New_Land_005a61a0 = "A New Land";
+
+// STRING: STRONGHOLDCRUSADER 0x005a61ac
+char const* const s_A_resourceful_divide_005a61ac = "A resourceful divide";
+
+// STRING: STRONGHOLDCRUSADER 0x005a61c4
+char const* const s_DirectDrawCreateEx_005a61c4 = "DirectDrawCreateEx";
+
+// STRING: STRONGHOLDCRUSADER 0x005a61d8
+char const* const s_DirectDrawCreate_005a61d8 = "DirectDrawCreate";
+
+// STRING: STRONGHOLDCRUSADER 0x005a61ec
+char const* const s_DDRAW_DLL_005a61ec = "DDRAW.DLL";
+
+// STRING: STRONGHOLDCRUSADER 0x005a6208
+char const* const s_Vid__d__sys__d_005a6208 = "Vid %d, sys %d";
+
+// STRING: STRONGHOLDCRUSADER 0x005a6218
+char const* const s_scimitar_ani_005a6218 = "scimitar.ani";
+
+// STRING: STRONGHOLDCRUSADER 0x005a6228
+char const* const s_delete_not_ani_005a6228 = "delete_not.ani";
+
+// STRING: STRONGHOLDCRUSADER 0x005a6238
+char const* const s_hand_ani_005a6238 = "hand.ani";
+
+// STRING: STRONGHOLDCRUSADER 0x005a6244
+char const* const s_jester_ani_005a6244 = "jester.ani";
+
+// STRING: STRONGHOLDCRUSADER 0x005a6250
+char const* const s_delete_ani_005a6250 = "delete.ani";
+
+// STRING: STRONGHOLDCRUSADER 0x005a625c
+char const* const s_sword_ani_005a625c = "sword.ani";
+
+// STRING: STRONGHOLDCRUSADER 0x005a6268
+char const* const s_Select_TGX_file_to_import_005a6268 = "Select TGX file to import";
+
+// STRING: STRONGHOLDCRUSADER 0x005a6284
+char const* const s_Select_help_file_to_save_005a6284 = "Select help file to save";
+
+// STRING: STRONGHOLDCRUSADER 0x005a62a0
+char const* const s_Select_sound_file_to_import_005a62a0 = "Select sound file to import";
+
+// STRING: STRONGHOLDCRUSADER 0x005a62f8
+char const* const s_SPANISH_005a62f8 = "SPANISH";
+
+// STRING: STRONGHOLDCRUSADER 0x005a6300
+char const* const s_italian_005a6300 = "italian";
+
+// STRING: STRONGHOLDCRUSADER 0x005a6308
+char const* const s_french_005a6308 = "french";
+
+// STRING: STRONGHOLDCRUSADER 0x005a6310
+char const* const s_german_005a6310 = "german";
+
+// STRING: STRONGHOLDCRUSADER 0x005a6318
+char const* const s_american_005a6318 = "american";
+
+// STRING: STRONGHOLDCRUSADER 0x005a6324
+char const* const s_english_005a6324 = "english";
+
+// STRING: STRONGHOLDCRUSADER 0x005a632c
+char const* const s_polish_005a632c = "polish";
+
+// STRING: STRONGHOLDCRUSADER 0x005a6334
+char const* const s_cr_tex_005a6334 = "cr.tex";
+
+// STRING: STRONGHOLDCRUSADER 0x005a633c
+char const* const s_Err_raw__d_005a633c = "Err:raw %d";
+
+// STRING: STRONGHOLDCRUSADER 0x005a6348
+char const* const s_Err_cmp__d_005a6348 = "Err:cmp %d";
+
+// STRING: STRONGHOLDCRUSADER 0x005a63a8
+char const* const s_bad_locale_name_005a63a8 = "bad locale name";
+
+// STRING: STRONGHOLDCRUSADER 0x005a63e8
+char const* const s_C_005a63e8 = "C";
+
+// STRING: STRONGHOLDCRUSADER 0x005a63ec
+char const* const s_ios_base_eofbit_set_005a63ec = "ios_base::eofbit set";
+
+// STRING: STRONGHOLDCRUSADER 0x005a6404
+char const* const s_ios_base_failbit_set_005a6404 = "ios_base::failbit set";
+
+// STRING: STRONGHOLDCRUSADER 0x005a641c
+char const* const s_ios_base_badbit_set_005a641c = "ios_base::badbit set";
+
+// STRING: STRONGHOLDCRUSADER 0x005a6434
+char const* const s__Stronghold_Crusader__005a6434 = "\\Stronghold Crusader\\";
+
+// STRING: STRONGHOLDCRUSADER 0x005a644c
+char const* const s_Saves__005a644c = "Saves\\";
+
+// STRING: STRONGHOLDCRUSADER 0x005a6454
+char const* const s_Maps__005a6454 = "Maps\\";
+
+// STRING: STRONGHOLDCRUSADER 0x005a645c
+char const* const s_bad_cast_005a645c = "bad cast";
+
+// STRING: STRONGHOLDCRUSADER 0x005a648c
+char const* const s__map_005a648c = "*.map";
+
+// STRING: STRONGHOLDCRUSADER 0x005a6494
+char const* const s_mission_005a6494 = "mission";
+
+// STRING: STRONGHOLDCRUSADER 0x005a649c
+char const* const s_mapsExtreme_map_005a649c = "mapsExtreme\\*.map";
+
+// STRING: STRONGHOLDCRUSADER 0x005a64b0
+char const* const s_maps_map_005a64b0 = "maps\\*.map";
+
+// STRING: STRONGHOLDCRUSADER 0x005a64bc
+char const* const s_scores__005a64bc = "scores\\";
+
+// STRING: STRONGHOLDCRUSADER 0x005a64c4
+char const* const s_maps__005a64c4 = "maps\\";
+
+// STRING: STRONGHOLDCRUSADER 0x005a64cc
+char const* const s_fx_speech__005a64cc = "fx\\speech\\";
+
+// STRING: STRONGHOLDCRUSADER 0x005a64d8
+char const* const s_binks__005a64d8 = "binks\\";
+
+// STRING: STRONGHOLDCRUSADER 0x005a64e0
+char const* const s_castles__005a64e0 = "castles\\";
+
+// STRING: STRONGHOLDCRUSADER 0x005a64ec
+char const* const s_gfx8__005a64ec = "gfx8\\";
+
+// STRING: STRONGHOLDCRUSADER 0x005a64f4
+char const* const s_scenarios__005a64f4 = "scenarios\\";
+
+// STRING: STRONGHOLDCRUSADER 0x005a6500
+char const* const s_faces_bmp_005a6500 = "faces.bmp";
+
+// STRING: STRONGHOLDCRUSADER 0x005a651c
+char const* const DAT_BMP_MagicValue = "BM";
+
+// STRING: STRONGHOLDCRUSADER 0x005a6520
+char const* const s_screen_capture__03d_bmp_005a6520 = "screen_capture_%03d.bmp";
+
+// STRING: STRONGHOLDCRUSADER 0x005a6538
+char const* const s_screen_capture_bmp_005a6538 = "screen_capture.bmp";
+
+// STRING: STRONGHOLDCRUSADER 0x005a654c
+char const* const s_fx_music_flt_19_raw_005a654c = "fx\\music\\flt_19.raw";
+
+// STRING: STRONGHOLDCRUSADER 0x005a6560
+char const* const s_fx_music_flt_18_raw_005a6560 = "fx\\music\\flt_18.raw";
+
+// STRING: STRONGHOLDCRUSADER 0x005a6574
+char const* const s_fx_music_flt_17_raw_005a6574 = "fx\\music\\flt_17.raw";
+
+// STRING: STRONGHOLDCRUSADER 0x005a6588
+char const* const s_fx_music_flt_16_raw_005a6588 = "fx\\music\\flt_16.raw";
+
+// STRING: STRONGHOLDCRUSADER 0x005a659c
+char const* const s_fx_music_flt_15_raw_005a659c = "fx\\music\\flt_15.raw";
+
+// STRING: STRONGHOLDCRUSADER 0x005a65b0
+char const* const s_fx_music_flt_14_raw_005a65b0 = "fx\\music\\flt_14.raw";
+
+// STRING: STRONGHOLDCRUSADER 0x005a65c4
+char const* const s_fx_music_flt_13_raw_005a65c4 = "fx\\music\\flt_13.raw";
+
+// STRING: STRONGHOLDCRUSADER 0x005a65d8
+char const* const s_fx_music_flt_12_raw_005a65d8 = "fx\\music\\flt_12.raw";
+
+// STRING: STRONGHOLDCRUSADER 0x005a65ec
+char const* const s_fx_music_flt_11_raw_005a65ec = "fx\\music\\flt_11.raw";
+
+// STRING: STRONGHOLDCRUSADER 0x005a6600
+char const* const s_fx_music_flt_10_raw_005a6600 = "fx\\music\\flt_10.raw";
+
+// STRING: STRONGHOLDCRUSADER 0x005a6614
+char const* const s_fx_music_flt_09_raw_005a6614 = "fx\\music\\flt_09.raw";
+
+// STRING: STRONGHOLDCRUSADER 0x005a6628
+char const* const s_fx_music_flt_08_raw_005a6628 = "fx\\music\\flt_08.raw";
+
+// STRING: STRONGHOLDCRUSADER 0x005a663c
+char const* const s_fx_music_flt_06_raw_005a663c = "fx\\music\\flt_06.raw";
+
+// STRING: STRONGHOLDCRUSADER 0x005a6650
+char const* const s_fx_music_flt_05_raw_005a6650 = "fx\\music\\flt_05.raw";
+
+// STRING: STRONGHOLDCRUSADER 0x005a6664
+char const* const s_fx_music_flt_03_raw_005a6664 = "fx\\music\\flt_03.raw";
+
+// STRING: STRONGHOLDCRUSADER 0x005a6678
+char const* const s_fx_music_flt_02_raw_005a6678 = "fx\\music\\flt_02.raw";
+
+// STRING: STRONGHOLDCRUSADER 0x005a668c
+char const* const s_fx_music_flt_01_raw_005a668c = "fx\\music\\flt_01.raw";
+
+// STRING: STRONGHOLDCRUSADER 0x005a66a0
+char const* const s_fx_music_oud_24_raw_005a66a0 = "fx\\music\\oud_24.raw";
+
+// STRING: STRONGHOLDCRUSADER 0x005a66b4
+char const* const s_fx_music_oud_23_raw_005a66b4 = "fx\\music\\oud_23.raw";
+
+// STRING: STRONGHOLDCRUSADER 0x005a66c8
+char const* const s_fx_music_oud_22_raw_005a66c8 = "fx\\music\\oud_22.raw";
+
+// STRING: STRONGHOLDCRUSADER 0x005a66dc
+char const* const s_fx_music_oud_21_raw_005a66dc = "fx\\music\\oud_21.raw";
+
+// STRING: STRONGHOLDCRUSADER 0x005a66f0
+char const* const s_fx_music_oud_19_raw_005a66f0 = "fx\\music\\oud_19.raw";
+
+// STRING: STRONGHOLDCRUSADER 0x005a6704
+char const* const s_fx_music_oud_18_raw_005a6704 = "fx\\music\\oud_18.raw";
+
+// STRING: STRONGHOLDCRUSADER 0x005a6718
+char const* const s_fx_music_oud_17_raw_005a6718 = "fx\\music\\oud_17.raw";
+
+// STRING: STRONGHOLDCRUSADER 0x005a672c
+char const* const s_fx_music_oud_16_raw_005a672c = "fx\\music\\oud_16.raw";
+
+// STRING: STRONGHOLDCRUSADER 0x005a6740
+char const* const s_fx_music_oud_15_raw_005a6740 = "fx\\music\\oud_15.raw";
+
+// STRING: STRONGHOLDCRUSADER 0x005a6754
+char const* const s_fx_music_oud_14_raw_005a6754 = "fx\\music\\oud_14.raw";
+
+// STRING: STRONGHOLDCRUSADER 0x005a6768
+char const* const s_fx_music_oud_13_raw_005a6768 = "fx\\music\\oud_13.raw";
+
+// STRING: STRONGHOLDCRUSADER 0x005a677c
+char const* const s_fx_music_oud_12_raw_005a677c = "fx\\music\\oud_12.raw";
+
+// STRING: STRONGHOLDCRUSADER 0x005a6790
+char const* const s_fx_music_oud_11_raw_005a6790 = "fx\\music\\oud_11.raw";
+
+// STRING: STRONGHOLDCRUSADER 0x005a67a4
+char const* const s_fx_music_oud_20_raw_005a67a4 = "fx\\music\\oud_20.raw";
+
+// STRING: STRONGHOLDCRUSADER 0x005a67b8
+char const* const s_fx_music_oud_09_raw_005a67b8 = "fx\\music\\oud_09.raw";
+
+// STRING: STRONGHOLDCRUSADER 0x005a67cc
+char const* const s_fx_music_oud_08_raw_005a67cc = "fx\\music\\oud_08.raw";
+
+// STRING: STRONGHOLDCRUSADER 0x005a67e0
+char const* const s_fx_music_oud_07_raw_005a67e0 = "fx\\music\\oud_07.raw";
+
+// STRING: STRONGHOLDCRUSADER 0x005a67f4
+char const* const s_fx_music_oud_06_raw_005a67f4 = "fx\\music\\oud_06.raw";
+
+// STRING: STRONGHOLDCRUSADER 0x005a6808
+char const* const s_fx_music_oud_05_raw_005a6808 = "fx\\music\\oud_05.raw";
+
+// STRING: STRONGHOLDCRUSADER 0x005a681c
+char const* const s_fx_music_oud_04_raw_005a681c = "fx\\music\\oud_04.raw";
+
+// STRING: STRONGHOLDCRUSADER 0x005a6830
+char const* const s_fx_music_oud_03_raw_005a6830 = "fx\\music\\oud_03.raw";
+
+// STRING: STRONGHOLDCRUSADER 0x005a6844
+char const* const s_fx_music_oud_02_raw_005a6844 = "fx\\music\\oud_02.raw";
+
+// STRING: STRONGHOLDCRUSADER 0x005a6858
+char const* const s_fx_music_oud_01_raw_005a6858 = "fx\\music\\oud_01.raw";
+
+// STRING: STRONGHOLDCRUSADER 0x005a686c
+char const* const s_fx_music_flt_07_raw_005a686c = "fx\\music\\flt_07.raw";
+
+// STRING: STRONGHOLDCRUSADER 0x005a6880
+char const* const s_fx_music_flt_narr1_raw_005a6880 = "fx\\music\\flt_narr1.raw";
+
+// STRING: STRONGHOLDCRUSADER 0x005a6898
+char const* const s_fx_music_solovln_01_raw_005a6898 = "fx\\music\\solovln_01.raw";
+
+// STRING: STRONGHOLDCRUSADER 0x005a68b0
+char const* const s_fx_music_flt_04_raw_005a68b0 = "fx\\music\\flt_04.raw";
+
+// STRING: STRONGHOLDCRUSADER 0x005a68c4
+char const* const s_fx_music_crusader_raw_005a68c4 = "fx\\music\\crusader.raw";
+
+// STRING: STRONGHOLDCRUSADER 0x005a68dc
+char const* const s_fx_music_bigloss2_raw_005a68dc = "fx\\music\\bigloss2.raw";
+
+// STRING: STRONGHOLDCRUSADER 0x005a68f4
+char const* const s_fx_music_bigloss1_raw_005a68f4 = "fx\\music\\bigloss1.raw";
+
+// STRING: STRONGHOLDCRUSADER 0x005a690c
+char const* const s_fx_music_bigwin3_raw_005a690c = "fx\\music\\bigwin3.raw";
+
+// STRING: STRONGHOLDCRUSADER 0x005a6924
+char const* const s_fx_music_bigwin2_raw_005a6924 = "fx\\music\\bigwin2.raw";
+
+// STRING: STRONGHOLDCRUSADER 0x005a693c
+char const* const s_fx_music_bigwin1_raw_005a693c = "fx\\music\\bigwin1.raw";
+
+// STRING: STRONGHOLDCRUSADER 0x005a6954
+char const* const s_fx_music_drumloop1b_raw_005a6954 = "fx\\music\\drumloop1b.raw";
+
+// STRING: STRONGHOLDCRUSADER 0x005a696c
+char const* const s_fx_music_drumloop1a_raw_005a696c = "fx\\music\\drumloop1a.raw";
+
+// STRING: STRONGHOLDCRUSADER 0x005a6984
+char const* const s_fx_music_glory_06_raw_005a6984 = "fx\\music\\glory_06.raw";
+
+// STRING: STRONGHOLDCRUSADER 0x005a699c
+char const* const s_fx_music_glory_05_raw_005a699c = "fx\\music\\glory_05.raw";
+
+// STRING: STRONGHOLDCRUSADER 0x005a69b4
+char const* const s_fx_music_glory_04_raw_005a69b4 = "fx\\music\\glory_04.raw";
+
+// STRING: STRONGHOLDCRUSADER 0x005a69cc
+char const* const s_fx_music_glory_03_raw_005a69cc = "fx\\music\\glory_03.raw";
+
+// STRING: STRONGHOLDCRUSADER 0x005a69e4
+char const* const s_fx_music_glory_02_raw_005a69e4 = "fx\\music\\glory_02.raw";
+
+// STRING: STRONGHOLDCRUSADER 0x005a69fc
+char const* const s_fx_music_glory_01_raw_005a69fc = "fx\\music\\glory_01.raw";
+
+// STRING: STRONGHOLDCRUSADER 0x005a6a14
+char const* const s_fx_music_honor_05_raw_005a6a14 = "fx\\music\\honor_05.raw";
+
+// STRING: STRONGHOLDCRUSADER 0x005a6a2c
+char const* const s_fx_music_honor_04_raw_005a6a2c = "fx\\music\\honor_04.raw";
+
+// STRING: STRONGHOLDCRUSADER 0x005a6a44
+char const* const s_fx_music_honor_03_raw_005a6a44 = "fx\\music\\honor_03.raw";
+
+// STRING: STRONGHOLDCRUSADER 0x005a6a5c
+char const* const s_fx_music_honor_02_raw_005a6a5c = "fx\\music\\honor_02.raw";
+
+// STRING: STRONGHOLDCRUSADER 0x005a6a74
+char const* const s_fx_music_percloop1_raw_005a6a74 = "fx\\music\\percloop1.raw";
+
+// STRING: STRONGHOLDCRUSADER 0x005a6a8c
+char const* const s_fx_music_drumloop1c_raw_005a6a8c = "fx\\music\\drumloop1c.raw";
+
+// STRING: STRONGHOLDCRUSADER 0x005a6aa4
+char const* const s_fx_music_suspense2c_raw_005a6aa4 = "fx\\music\\suspense2c.raw";
+
+// STRING: STRONGHOLDCRUSADER 0x005a6abc
+char const* const s_fx_music_suspense2b_raw_005a6abc = "fx\\music\\suspense2b.raw";
+
+// STRING: STRONGHOLDCRUSADER 0x005a6ad4
+char const* const s_fx_music_suspense2a_raw_005a6ad4 = "fx\\music\\suspense2a.raw";
+
+// STRING: STRONGHOLDCRUSADER 0x005a6aec
+char const* const s_fx_music_suspense1b_raw_005a6aec = "fx\\music\\suspense1b.raw";
+
+// STRING: STRONGHOLDCRUSADER 0x005a6b04
+char const* const s_fx_music_suspense1a_raw_005a6b04 = "fx\\music\\suspense1a.raw";
+
+// STRING: STRONGHOLDCRUSADER 0x005a6b1c
+char const* const s_fx_music_end_music_raw_005a6b1c = "fx\\music\\end_music.raw";
+
+// STRING: STRONGHOLDCRUSADER 0x005a6b34
+char const* const s_fx_music_cameltoe_raw_005a6b34 = "fx\\music\\cameltoe.raw";
+
+// STRING: STRONGHOLDCRUSADER 0x005a6b4c
+char const* const s_fx_music_dar_meshq_raw_005a6b4c = "fx\\music\\dar meshq.raw";
+
+// STRING: STRONGHOLDCRUSADER 0x005a6b64
+char const* const s_fx_music_sandalmaker_raw_005a6b64 = "fx\\music\\sandalmaker.raw";
+
+// STRING: STRONGHOLDCRUSADER 0x005a6b80
+char const* const s_fx_music_caravan_raw_005a6b80 = "fx\\music\\caravan.raw";
+
+// STRING: STRONGHOLDCRUSADER 0x005a6b98
+char const* const s_fx_music_thelastdrop_raw_005a6b98 = "fx\\music\\thelastdrop.raw";
+
+// STRING: STRONGHOLDCRUSADER 0x005a6bb4
+char const* const s_fx_music_crusader_solo_raw_005a6bb4 = "fx\\music\\crusader_solo.raw";
+
+// STRING: STRONGHOLDCRUSADER 0x005a6bd0
+char const* const s_fx_music_trancefusion_raw_005a6bd0 = "fx\\music\\trancefusion.raw";
+
+// STRING: STRONGHOLDCRUSADER 0x005a6bec
+char const* const s_fx_music_caravan_ambient_raw_005a6bec = "fx\\music\\caravan_ambient.raw";
+
+// STRING: STRONGHOLDCRUSADER 0x005a6c0c
+char const* const s_fx_music_apaneintheglass_raw_005a6c0c = "fx\\music\\apaneintheglass.raw";
+
+// STRING: STRONGHOLDCRUSADER 0x005a6c2c
+char const* const s_fx_music_stainedglass1_raw_005a6c2c = "fx\\music\\stainedglass1.raw";
+
+// STRING: STRONGHOLDCRUSADER 0x005a6c48
+char const* const s_fx_music_monks1_raw_005a6c48 = "fx\\music\\monks1.raw";
+
+// STRING: STRONGHOLDCRUSADER 0x005a6c5c
+char const* const s_fx_music_null_raw_005a6c5c = "fx\\music\\null.raw";
+
+// STRING: STRONGHOLDCRUSADER 0x005a6c70
+char const* const s_fx_music_astrongspice_raw_005a6c70 = "fx\\music\\astrongspice.raw";
+
+// STRING: STRONGHOLDCRUSADER 0x005a6c8c
+char const* const s_fx_music_sand_wedgie_raw_005a6c8c = "fx\\music\\sand wedgie.raw";
+
+// STRING: STRONGHOLDCRUSADER 0x005a6ca8
+char const* const s_fx_music_demopiece_22k_raw_005a6ca8 = "fx\\music\\demopiece 22k.raw";
+
+// STRING: STRONGHOLDCRUSADER 0x005a6cc4
+char const* const s__wav_005a6cc4 = ".wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a6ccc
+char const* const s_General_Warning4_wav_005a6ccc = "General_Warning4.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a6ce4
+char const* const s_General_Warning15_wav_005a6ce4 = "General_Warning15.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a6cfc
+char const* const s_miles_005a6cfc = "miles";
+
+// STRING: STRONGHOLDCRUSADER 0x005a6d04
+char const* const s_insult20_wav_005a6d04 = "insult20.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a6d14
+char const* const s_insult19_wav_005a6d14 = "insult19.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a6d24
+char const* const s_insult18_wav_005a6d24 = "insult18.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a6d34
+char const* const s_insult17_wav_005a6d34 = "insult17.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a6d44
+char const* const s_insult16_wav_005a6d44 = "insult16.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a6d54
+char const* const s_insult15_wav_005a6d54 = "insult15.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a6d64
+char const* const s_insult14_wav_005a6d64 = "insult14.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a6d74
+char const* const s_insult13_wav_005a6d74 = "insult13.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a6d84
+char const* const s_insult12_wav_005a6d84 = "insult12.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a6d94
+char const* const s_insult11_wav_005a6d94 = "insult11.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a6da4
+char const* const s_insult10_wav_005a6da4 = "insult10.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a6db4
+char const* const s_insult9_wav_005a6db4 = "insult9.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a6dc0
+char const* const s_insult8_wav_005a6dc0 = "insult8.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a6dcc
+char const* const s_insult7_wav_005a6dcc = "insult7.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a6dd8
+char const* const s_insult6_wav_005a6dd8 = "insult6.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a6de4
+char const* const s_insult5_wav_005a6de4 = "insult5.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a6df0
+char const* const s_insult4_wav_005a6df0 = "insult4.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a6dfc
+char const* const s_insult3_wav_005a6dfc = "insult3.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a6e08
+char const* const s_insult2_wav_005a6e08 = "insult2.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a6e14
+char const* const s_insult1_wav_005a6e14 = "insult1.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a6f00
+char const* const s__d_d_d_d_005a6f00 = "   %d.%d.%d.%d";
+
+// STRING: STRONGHOLDCRUSADER 0x005a6f10
+char const* const s__d_d_d_d____d_d_d_d_005a6f10 = "   %d.%d.%d.%d  /  %d.%d.%d.%d";
+
+// STRING: STRONGHOLDCRUSADER 0x005a6f30
+char const* const s_Stronghold_s_005a6f30 = "Stronghold-%s";
+
+// STRING: STRONGHOLDCRUSADER 0x005a6f54
+char const* const s_aphex_exe_005a6f54 = "aphex.exe";
+
+// STRING: STRONGHOLDCRUSADER 0x005a6f60
+char const* const s___005a6f60 = "\\";
+
+// STRING: STRONGHOLDCRUSADER 0x005a6f64
+char const* const s_InstDir_005a6f64 = "InstDir";
+
+// STRING: STRONGHOLDCRUSADER 0x005a6f6c
+char const* const s_Software_GameSpy_GameSpy_Arcade_005a6f6c = "Software\\GameSpy\\GameSpy Arcade";
+
+// STRING: STRONGHOLDCRUSADER 0x005a6f8c
+char const* const s_Error_DirectPlay_unknown__x_005a6f8c = "Error:DirectPlay unknown %x";
+
+// STRING: STRONGHOLDCRUSADER 0x005a6fa8
+char const* const s_First_split_zone__005a6fa8 = "First split zone:  ";
+
+// STRING: STRONGHOLDCRUSADER 0x005a6fbc
+char const* const s_Total_split_zones__005a6fbc = "Total split zones:  ";
+
+// STRING: STRONGHOLDCRUSADER 0x005a6fd4
+char const* const s_First_split_pitch_ditch__005a6fd4 = "First split pitch ditch:  ";
+
+// STRING: STRONGHOLDCRUSADER 0x005a6ff0
+char const* const s_Total_split_pitch_ditchs__005a6ff0 = "Total split pitch ditchs:  ";
+
+// STRING: STRONGHOLDCRUSADER 0x005a700c
+char const* const s_First_split_teleport__005a700c = "First split teleport:  ";
+
+// STRING: STRONGHOLDCRUSADER 0x005a7024
+char const* const s_Total_split_teleports__005a7024 = "Total split teleports:  ";
+
+// STRING: STRONGHOLDCRUSADER 0x005a7040
+char const* const s_First_split_moat__005a7040 = "First split moat:  ";
+
+// STRING: STRONGHOLDCRUSADER 0x005a7054
+char const* const s_Total_split_moats__005a7054 = "Total split moats:  ";
+
+// STRING: STRONGHOLDCRUSADER 0x005a706c
+char const* const s_First_split_fly__005a706c = "First split fly:  ";
+
+// STRING: STRONGHOLDCRUSADER 0x005a7080
+char const* const s_Total_split_flies__005a7080 = "Total split flies:  ";
+
+// STRING: STRONGHOLDCRUSADER 0x005a7098
+char const* const s_First_split_layer__005a7098 = "First split layer:  ";
+
+// STRING: STRONGHOLDCRUSADER 0x005a70b0
+char const* const s_Total_split_layers__005a70b0 = "Total split layers:  ";
+
+// STRING: STRONGHOLDCRUSADER 0x005a70c8
+char const* const s_First_split_element__005a70c8 = "First split element:  ";
+
+// STRING: STRONGHOLDCRUSADER 0x005a70e0
+char const* const s_Total_split_elements__005a70e0 = "Total split elements:  ";
+
+// STRING: STRONGHOLDCRUSADER 0x005a70f8
+char const* const s_First_split_player__005a70f8 = "First split player:  ";
+
+// STRING: STRONGHOLDCRUSADER 0x005a7110
+char const* const s_Total_split_players__005a7110 = "Total split players:  ";
+
+// STRING: STRONGHOLDCRUSADER 0x005a7128
+char const* const s_First_split_tribe__005a7128 = "First split tribe:  ";
+
+// STRING: STRONGHOLDCRUSADER 0x005a7140
+char const* const s_Total_split_tribes__005a7140 = "Total split tribes:  ";
+
+// STRING: STRONGHOLDCRUSADER 0x005a7158
+char const* const s_First_split_veg__005a7158 = "First split veg:  ";
+
+// STRING: STRONGHOLDCRUSADER 0x005a716c
+char const* const s_Total_split_veg__005a716c = "Total split veg:  ";
+
+// STRING: STRONGHOLDCRUSADER 0x005a7180
+char const* const s_First_split_structure__005a7180 = "First split structure:  ";
+
+// STRING: STRONGHOLDCRUSADER 0x005a719c
+char const* const s_Total_split_structures__005a719c = "Total split structures:  ";
+
+// STRING: STRONGHOLDCRUSADER 0x005a71b8
+char const* const s_First_split_chimp__005a71b8 = "First split chimp:  ";
+
+// STRING: STRONGHOLDCRUSADER 0x005a71d0
+char const* const s_Total_split_chimps__005a71d0 = "Total split chimps:  ";
+
+// STRING: STRONGHOLDCRUSADER 0x005a71e8
+char const* const s_Total_split_data_items__005a71e8 = "Total split data items:  ";
+
+// STRING: STRONGHOLDCRUSADER 0x005a7204
+char const* const s___Game_elements_005a7204 = " - Game elements";
+
+// STRING: STRONGHOLDCRUSADER 0x005a7218
+char const* const s___Players_005a7218 = " - Players";
+
+// STRING: STRONGHOLDCRUSADER 0x005a7224
+char const* const s___Tribes_005a7224 = " - Tribes";
+
+// STRING: STRONGHOLDCRUSADER 0x005a7230
+char const* const s___Vegetation_005a7230 = " - Vegetation";
+
+// STRING: STRONGHOLDCRUSADER 0x005a7240
+char const* const s___Structures_005a7240 = " - Structures";
+
+// STRING: STRONGHOLDCRUSADER 0x005a7250
+char const* const s___Chimps_005a7250 = " - Chimps";
+
+// STRING: STRONGHOLDCRUSADER 0x005a725c
+char const* const s_Splinter_box_005a725c = "Splinter box ";
+
+// STRING: STRONGHOLDCRUSADER 0x005a7270
+char const* const s_ABCDEFGHIJKLMNOPQRSTUVWXYZabcdef_005a7270
+    = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+$";
+
+// STRING: STRONGHOLDCRUSADER 0x005a72b4
+char const* const s_packet_size_d_new_size_d_type__005a72b4 = "packet size:%d new size:%d type:%d";
+
+// STRING: STRONGHOLDCRUSADER 0x005a72d8
+char const* const s_ID_d_OF_d_M_d_S_d_005a72d8 = "ID:%d OF:%d M:%d S:%d";
+
+// STRING: STRONGHOLDCRUSADER 0x005a72f0
+char const* const s_GT__005a72f0 = "GT: ";
+
+// STRING: STRONGHOLDCRUSADER 0x005a72f8
+char const* const s_Multi_Op__005a72f8 = "Multi Op: ";
+
+// STRING: STRONGHOLDCRUSADER 0x005a7304
+char const* const s___005a7304 = ", ";
+
+// STRING: STRONGHOLDCRUSADER 0x005a7308
+char const* const s_Battle_Level__005a7308 = "Battle Level: ";
+
+// STRING: STRONGHOLDCRUSADER 0x005a7318
+char const* const s_Clans__005a7318 = "Clans: ";
+
+// STRING: STRONGHOLDCRUSADER 0x005a7320
+char const* const s_cl_time_diff__005a7320 = "cl time_diff: ";
+
+// STRING: STRONGHOLDCRUSADER 0x005a7330
+char const* const s_pending_chores__005a7330 = "pending_chores: ";
+
+// STRING: STRONGHOLDCRUSADER 0x005a7344
+char const* const s_chore_latency__005a7344 = "chore_latency: ";
+
+// STRING: STRONGHOLDCRUSADER 0x005a7354
+char const* const s_random_no__005a7354 = "random no: ";
+
+// STRING: STRONGHOLDCRUSADER 0x005a7360
+char const* const s_id_count__005a7360 = "id_count: ";
+
+// STRING: STRONGHOLDCRUSADER 0x005a736c
+char const* const s_Structs__005a736c = "Structs: ";
+
+// STRING: STRONGHOLDCRUSADER 0x005a7378
+char const* const s_Chimps__005a7378 = "Chimps: ";
+
+// STRING: STRONGHOLDCRUSADER 0x005a7384
+char const* const s_ZONE__005a7384 = "  ZONE:";
+
+// STRING: STRONGHOLDCRUSADER 0x005a738c
+char const* const s_PIDI__005a738c = "  PIDI:";
+
+// STRING: STRONGHOLDCRUSADER 0x005a7394
+char const* const s_TELE__005a7394 = "  TELE:";
+
+// STRING: STRONGHOLDCRUSADER 0x005a739c
+char const* const s_MOAT__005a739c = "  MOAT:";
+
+// STRING: STRONGHOLDCRUSADER 0x005a73a4
+char const* const s_FLY__005a73a4 = "  FLY:";
+
+// STRING: STRONGHOLDCRUSADER 0x005a73ac
+char const* const s_LAY__005a73ac = "  LAY:";
+
+// STRING: STRONGHOLDCRUSADER 0x005a73b4
+char const* const s_GAM__005a73b4 = "GAM:";
+
+// STRING: STRONGHOLDCRUSADER 0x005a73bc
+char const* const s_PLA__005a73bc = "  PLA:";
+
+// STRING: STRONGHOLDCRUSADER 0x005a73c4
+char const* const s_TRI__005a73c4 = "  TRI:";
+
+// STRING: STRONGHOLDCRUSADER 0x005a73cc
+char const* const s_VEG__005a73cc = "  VEG:";
+
+// STRING: STRONGHOLDCRUSADER 0x005a73d4
+char const* const s_STR__005a73d4 = "  STR:";
+
+// STRING: STRONGHOLDCRUSADER 0x005a73dc
+char const* const s_CHI__005a73dc = "CHI:";
+
+// STRING: STRONGHOLDCRUSADER 0x005a73e4
+char const* const s_Game_in_sync_005a73e4 = "Game in sync";
+
+// STRING: STRONGHOLDCRUSADER 0x005a73f4
+char const* const s_GAME_SPLINTERED_005a73f4 = "GAME SPLINTERED ";
+
+// STRING: STRONGHOLDCRUSADER 0x005a7408
+char const* const s_GAME_SPLINTERED___Resyncing_005a7408 = "GAME SPLINTERED - Resyncing";
+
+// STRING: STRONGHOLDCRUSADER 0x005a7424
+char const* const s_Crc_times_005a7424 = "Crc times ";
+
+// STRING: STRONGHOLDCRUSADER 0x005a7430
+char const* const s_Crcs_005a7430 = "Crcs ";
+
+// STRING: STRONGHOLDCRUSADER 0x005a7438
+char const* const s_Logical_speed__005a7438 = " Logical speed: ";
+
+// STRING: STRONGHOLDCRUSADER 0x005a744c
+char const* const s_Relative_time__005a744c = "Relative time: ";
+
+// STRING: STRONGHOLDCRUSADER 0x005a745c
+char const* const s___005a745c = ":";
+
+// STRING: STRONGHOLDCRUSADER 0x005a7460
+char const* const s_p_005a7460 = " p";
+
+// STRING: STRONGHOLDCRUSADER 0x005a7464
+char const* const s_Timings_005a7464 = "Timings ";
+
+// STRING: STRONGHOLDCRUSADER 0x005a7470
+char const* const s_Adv__005a7470 = " Adv: ";
+
+// STRING: STRONGHOLDCRUSADER 0x005a7478
+char const* const s_Chores_used__005a7478 = "Chores used: ";
+
+// STRING: STRONGHOLDCRUSADER 0x005a7488
+char const* const s_Packets_in__005a7488 = "Packets in: ";
+
+// STRING: STRONGHOLDCRUSADER 0x005a7498
+char const* const s__msv_005a7498 = ".msv";
+
+// STRING: STRONGHOLDCRUSADER 0x005a74a0
+char const* const s_Glob__d_005a74a0 = "Glob %d";
+
+// STRING: STRONGHOLDCRUSADER 0x005a74a8
+char const* const s_Contestant_005a74a8 = "Contestant";
+
+// STRING: STRONGHOLDCRUSADER 0x005a74b4
+char const* const s_autosave_005a74b4 = "autosave";
+
+// STRING: STRONGHOLDCRUSADER 0x005a74c0
+char const* const s_DP_SYS_Message___x_005a74c0 = "DP SYS Message: %x";
+
+// STRING: STRONGHOLDCRUSADER 0x005a74d4
+char const* const s__name_005a74d4 = "+name";
+
+// STRING: STRONGHOLDCRUSADER 0x005a74dc
+char const* const s__host_005a74dc = "+host";
+
+// STRING: STRONGHOLDCRUSADER 0x005a74e4
+char const* const s__connect_005a74e4 = "+connect";
+
+// STRING: STRONGHOLDCRUSADER 0x005a74f0
+char const* const s_1600x900_005a74f0 = "1600x900";
+
+// STRING: STRONGHOLDCRUSADER 0x005a74fc
+char const* const s_1680x1050_005a74fc = "1680x1050";
+
+// STRING: STRONGHOLDCRUSADER 0x005a7508
+char const* const s_1360x768_005a7508 = "1360x768";
+
+// STRING: STRONGHOLDCRUSADER 0x005a7514
+char const* const s_1366x768_005a7514 = "1366x768";
+
+// STRING: STRONGHOLDCRUSADER 0x005a7520
+char const* const s_2560x1600_005a7520 = "2560x1600";
+
+// STRING: STRONGHOLDCRUSADER 0x005a752c
+char const* const s_2560x1440_005a752c = "2560x1440";
+
+// STRING: STRONGHOLDCRUSADER 0x005a7538
+char const* const s_1920x1200_005a7538 = "1920x1200";
+
+// STRING: STRONGHOLDCRUSADER 0x005a7544
+char const* const s_1920x1080_005a7544 = "1920x1080";
+
+// STRING: STRONGHOLDCRUSADER 0x005a7550
+char const* const s_1440x900_005a7550 = "1440x900";
+
+// STRING: STRONGHOLDCRUSADER 0x005a755c
+char const* const s_1280x720_005a755c = "1280x720";
+
+// STRING: STRONGHOLDCRUSADER 0x005a7568
+char const* const s_1600x1200_005a7568 = "1600x1200";
+
+// STRING: STRONGHOLDCRUSADER 0x005a7574
+char const* const s_1280x1024_005a7574 = "1280x1024";
+
+// STRING: STRONGHOLDCRUSADER 0x005a7580
+char const* const s_1024x768_005a7580 = "1024x768";
+
+// STRING: STRONGHOLDCRUSADER 0x005a758c
+char const* const s_1024x600_005a758c = "1024x600";
+
+// STRING: STRONGHOLDCRUSADER 0x005a7598
+char const* const s_800x600_005a7598 = "800x600";
+
+// STRING: STRONGHOLDCRUSADER 0x005a75a0
+char const* const s__sav_005a75a0 = ".sav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a75a8
+char const* const s__tmp_005a75a8 = ".tmp";
+
+// STRING: STRONGHOLDCRUSADER 0x005a75b0
+char const* const s_maps_tmp_005a75b0 = "maps\\*.tmp";
+
+// STRING: STRONGHOLDCRUSADER 0x005a75bc
+char const* const s_crusader_cfg_005a75bc = "crusader.cfg";
+
+// STRING: STRONGHOLDCRUSADER 0x005a75cc
+char const* const s__sav_005a75cc = "*.sav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a75d4
+char const* const s__msv_005a75d4 = "*.msv";
+
+// STRING: STRONGHOLDCRUSADER 0x005a75dc
+char const* const s_400x400_005a75dc = "400x400";
+
+// STRING: STRONGHOLDCRUSADER 0x005a75e4
+char const* const s_300x300_005a75e4 = "300x300";
+
+// STRING: STRONGHOLDCRUSADER 0x005a75ec
+char const* const s_200x200_005a75ec = "200x200";
+
+// STRING: STRONGHOLDCRUSADER 0x005a75f4
+char const* const s_160x160_005a75f4 = "160x160";
+
+// STRING: STRONGHOLDCRUSADER 0x005a75fc
+char const* const s_King_of_the_Hill_005a75fc = "King of the Hill";
+
+// STRING: STRONGHOLDCRUSADER 0x005a7610
+char const* const s_Multi_005a7610 = "Multi";
+
+// STRING: STRONGHOLDCRUSADER 0x005a7618
+char const* const s_Single_005a7618 = "Single";
+
+// STRING: STRONGHOLDCRUSADER 0x005a7620
+char const* const s_Just_Build_005a7620 = "Just Build";
+
+// STRING: STRONGHOLDCRUSADER 0x005a762c
+char const* const s_Economic_005a762c = "Economic";
+
+// STRING: STRONGHOLDCRUSADER 0x005a7638
+char const* const s_Invasion_005a7638 = "Invasion";
+
+// STRING: STRONGHOLDCRUSADER 0x005a7644
+char const* const s_Siege_005a7644 = "Siege";
+
+// STRING: STRONGHOLDCRUSADER 0x005a764c
+char const* const s_Mission_005a764c = "Mission";
+
+// STRING: STRONGHOLDCRUSADER 0x005a7654
+char const* const s_Playable_005a7654 = "Playable";
+
+// STRING: STRONGHOLDCRUSADER 0x005a7660
+char const* const s_Editable_005a7660 = "Editable";
+
+// STRING: STRONGHOLDCRUSADER 0x005a766c
+char const* const s__d__s_005a766c = "%d %s";
+
+// STRING: STRONGHOLDCRUSADER 0x005a7674
+char const* const s__d__s___005a7674 = "%d %s - ";
+
+// STRING: STRONGHOLDCRUSADER 0x005a7680
+char const* const s_Genie_02_wav_005a7680 = "Genie_02.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a7690
+char const* const s_genie_04_wav_005a7690 = "genie_04.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a76a0
+char const* const s_genie_10_wav_005a76a0 = "genie_10.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a76b0
+char const* const s_genie_09_wav_005a76b0 = "genie_09.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a76c0
+char const* const s_genie_08_wav_005a76c0 = "genie_08.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a76d0
+char const* const s_genie_07_wav_005a76d0 = "genie_07.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a76e0
+char const* const s_genie_06_wav_005a76e0 = "genie_06.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a76f0
+char const* const s_genie_05_wav_005a76f0 = "genie_05.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a7700
+char const* const s_Genie_14_wav_005a7700 = "Genie_14.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a7710
+char const* const s_Genie_13_wav_005a7710 = "Genie_13.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a7720
+char const* const s___Success_005a7720 = "% Success";
+
+// STRING: STRONGHOLDCRUSADER 0x005a772c
+char const* const s_Total_Success_005a772c = "Total Success";
+
+// STRING: STRONGHOLDCRUSADER 0x005a773c
+char const* const s_Can_t_place_keep_005a773c = "Can't place keep";
+
+// STRING: STRONGHOLDCRUSADER 0x005a7750
+char const* const s_File_missing_005a7750 = "File missing";
+
+// STRING: STRONGHOLDCRUSADER 0x005a7760
+char const* const s_Village_Placement_Success_005a7760 = "Village Placement Success";
+
+// STRING: STRONGHOLDCRUSADER 0x005a777c
+char const* const s_Mission___005a777c = "Mission :";
+
+// STRING: STRONGHOLDCRUSADER 0x005a7788
+char const* const s_Mission___Defaults_005a7788 = "Mission : Defaults";
+
+// STRING: STRONGHOLDCRUSADER 0x005a779c
+char const* const s_No_tree_growth_005a779c = "No tree growth";
+
+// STRING: STRONGHOLDCRUSADER 0x005a77ac
+char const* const s_other_warning2_wav_005a77ac = "other_warning2.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a77c0
+char const* const s_other_warning1_wav_005a77c0 = "other_warning1.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a77d4
+char const* const s_ms_005a77d4 = "ms";
+
+// STRING: STRONGHOLDCRUSADER 0x005a77d8
+char const* const s_battlehorn_wav_005a77d8 = "battlehorn.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a77e8
+char const* const s_game_running_wav_005a77e8 = "game_running.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a77fc
+char const* const s_game_paused_wav_005a77fc = "game_paused.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a780c
+char const* const s_bad_soldier_nevous_bik_005a780c = "bad_soldier_nevous.bik";
+
+// STRING: STRONGHOLDCRUSADER 0x005a7824
+char const* const s_bad_soldier_taunt_bik_005a7824 = "bad_soldier_taunt.bik";
+
+// STRING: STRONGHOLDCRUSADER 0x005a783c
+char const* const s_pg_vict3_bik_005a783c = "pg_vict3.bik";
+
+// STRING: STRONGHOLDCRUSADER 0x005a784c
+char const* const s_wf_vict2_bik_005a784c = "wf_vict2.bik";
+
+// STRING: STRONGHOLDCRUSADER 0x005a785c
+char const* const s_pg_vict2_bik_005a785c = "pg_vict2.bik";
+
+// STRING: STRONGHOLDCRUSADER 0x005a786c
+char const* const s_sn_vict1_bik_005a786c = "sn_vict1.bik";
+
+// STRING: STRONGHOLDCRUSADER 0x005a787c
+char const* const s_nazir_natural_bik_005a787c = "nazir_natural.bik";
+
+// STRING: STRONGHOLDCRUSADER 0x005a7890
+char const* const s_richard_natural_bik_005a7890 = "richard_natural.bik";
+
+// STRING: STRONGHOLDCRUSADER 0x005a78a4
+char const* const s_sultan_natural_bik_005a78a4 = "sultan_natural.bik";
+
+// STRING: STRONGHOLDCRUSADER 0x005a78b8
+char const* const s_saladin_natural_bik_005a78b8 = "saladin_natural.bik";
+
+// STRING: STRONGHOLDCRUSADER 0x005a78cc
+char const* const s_wf_vict1_bik_005a78cc = "wf_vict1.bik";
+
+// STRING: STRONGHOLDCRUSADER 0x005a78dc
+char const* const s_pg_vict1_bik_005a78dc = "pg_vict1.bik";
+
+// STRING: STRONGHOLDCRUSADER 0x005a78ec
+char const* const s_sn_vict2_bik_005a78ec = "sn_vict2.bik";
+
+// STRING: STRONGHOLDCRUSADER 0x005a78fc
+char const* const s_rt_vict1_bik_005a78fc = "rt_vict1.bik";
+
+// STRING: STRONGHOLDCRUSADER 0x005a790c
+char const* const s_ma_natural_bik_005a790c = "ma_natural.bik";
+
+// STRING: STRONGHOLDCRUSADER 0x005a791c
+char const* const s_vizir_natural_bik_005a791c = "vizir_natural.bik";
+
+// STRING: STRONGHOLDCRUSADER 0x005a7930
+char const* const s_richard_anger_bik_005a7930 = "richard_anger.bik";
+
+// STRING: STRONGHOLDCRUSADER 0x005a7944
+char const* const s_rt_plead3_bik_005a7944 = "rt_plead3.bik";
+
+// STRING: STRONGHOLDCRUSADER 0x005a7954
+char const* const s_fred_nervous_bik_005a7954 = "fred_nervous.bik";
+
+// STRING: STRONGHOLDCRUSADER 0x005a7968
+char const* const s_wf_plead2_bik_005a7968 = "wf_plead2.bik";
+
+// STRING: STRONGHOLDCRUSADER 0x005a7978
+char const* const s_pg_plead2_bik_005a7978 = "pg_plead2.bik";
+
+// STRING: STRONGHOLDCRUSADER 0x005a7988
+char const* const s_rt_plead2_bik_005a7988 = "rt_plead2.bik";
+
+// STRING: STRONGHOLDCRUSADER 0x005a7998
+char const* const s_sheriff_nervous_bik_005a7998 = "sheriff_nervous.bik";
+
+// STRING: STRONGHOLDCRUSADER 0x005a79ac
+char const* const s_nazir_nervous_bik_005a79ac = "nazir_nervous.bik";
+
+// STRING: STRONGHOLDCRUSADER 0x005a79c0
+char const* const s_vizir_nervous_bik_005a79c0 = "vizir_nervous.bik";
+
+// STRING: STRONGHOLDCRUSADER 0x005a79d4
+char const* const s_sultan_nervous_bik_005a79d4 = "sultan_nervous.bik";
+
+// STRING: STRONGHOLDCRUSADER 0x005a79e8
+char const* const s_bad_arab_nervous_bik_005a79e8 = "bad_arab_nervous.bik";
+
+// STRING: STRONGHOLDCRUSADER 0x005a7a00
+char const* const s_saladin_nervous_bik_005a7a00 = "saladin_nervous.bik";
+
+// STRING: STRONGHOLDCRUSADER 0x005a7a14
+char const* const s_wf_plead1_bik_005a7a14 = "wf_plead1.bik";
+
+// STRING: STRONGHOLDCRUSADER 0x005a7a24
+char const* const s_pg_plead1_bik_005a7a24 = "pg_plead1.bik";
+
+// STRING: STRONGHOLDCRUSADER 0x005a7a34
+char const* const s_sn_plead2_bik_005a7a34 = "sn_plead2.bik";
+
+// STRING: STRONGHOLDCRUSADER 0x005a7a44
+char const* const s_rt_plead1_bik_005a7a44 = "rt_plead1.bik";
+
+// STRING: STRONGHOLDCRUSADER 0x005a7a54
+char const* const s_abbot_nervous_bik_005a7a54 = "abbot_nervous.bik";
+
+// STRING: STRONGHOLDCRUSADER 0x005a7a68
+char const* const s_emir_nervous_bik_005a7a68 = "emir_nervous.bik";
+
+// STRING: STRONGHOLDCRUSADER 0x005a7a7c
+char const* const s_philip_anger_bik_005a7a7c = "philip_anger.bik";
+
+// STRING: STRONGHOLDCRUSADER 0x005a7a90
+char const* const s_abbot_angry_bik_005a7a90 = "abbot_angry.bik";
+
+// STRING: STRONGHOLDCRUSADER 0x005a7aa0
+char const* const s_ma_nervous_bik_005a7aa0 = "ma_nervous.bik";
+
+// STRING: STRONGHOLDCRUSADER 0x005a7ab0
+char const* const s_emir_angry_bik_005a7ab0 = "emir_angry.bik";
+
+// STRING: STRONGHOLDCRUSADER 0x005a7ac0
+char const* const s_philip_nervous_bik_005a7ac0 = "philip_nervous.bik";
+
+// STRING: STRONGHOLDCRUSADER 0x005a7ad4
+char const* const s_fred_anger_bik_005a7ad4 = "fred_anger.bik";
+
+// STRING: STRONGHOLDCRUSADER 0x005a7ae4
+char const* const s_richard_nervous_bik_005a7ae4 = "richard_nervous.bik";
+
+// STRING: STRONGHOLDCRUSADER 0x005a7af8
+char const* const s_sultan_anger_bik_005a7af8 = "sultan_anger.bik";
+
+// STRING: STRONGHOLDCRUSADER 0x005a7b0c
+char const* const s_saladin_angry_bik_005a7b0c = "saladin_angry.bik";
+
+// STRING: STRONGHOLDCRUSADER 0x005a7b20
+char const* const s_wf_anger1_bik_005a7b20 = "wf_anger1.bik";
+
+// STRING: STRONGHOLDCRUSADER 0x005a7b30
+char const* const s_pg_anger1_bik_005a7b30 = "pg_anger1.bik";
+
+// STRING: STRONGHOLDCRUSADER 0x005a7b40
+char const* const s_sn_anger1_bik_005a7b40 = "sn_anger1.bik";
+
+// STRING: STRONGHOLDCRUSADER 0x005a7b50
+char const* const s_rt_anger1_bik_005a7b50 = "rt_anger1.bik";
+
+// STRING: STRONGHOLDCRUSADER 0x005a7b60
+char const* const s_abbot_natural_bik_005a7b60 = "abbot_natural.bik";
+
+// STRING: STRONGHOLDCRUSADER 0x005a7b74
+char const* const s_ma_angry_bik_005a7b74 = "ma_angry.bik";
+
+// STRING: STRONGHOLDCRUSADER 0x005a7b84
+char const* const s_sheriff_anger_bik_005a7b84 = "sheriff_anger.bik";
+
+// STRING: STRONGHOLDCRUSADER 0x005a7b98
+char const* const s_fred_natural_bik_005a7b98 = "fred_natural.bik";
+
+// STRING: STRONGHOLDCRUSADER 0x005a7bac
+char const* const s_bad_arab_natural_bik_005a7bac = "bad_arab_natural.bik";
+
+// STRING: STRONGHOLDCRUSADER 0x005a7bc4
+char const* const s_sheriff_natural_bik_005a7bc4 = "sheriff_natural.bik";
+
+// STRING: STRONGHOLDCRUSADER 0x005a7bd8
+char const* const s_nazir_taunt_bik_005a7bd8 = "nazir_taunt.bik";
+
+// STRING: STRONGHOLDCRUSADER 0x005a7be8
+char const* const s_emir_natural_bik_005a7be8 = "emir_natural.bik";
+
+// STRING: STRONGHOLDCRUSADER 0x005a7bfc
+char const* const s_vizir_angry_bik_005a7bfc = "vizir_angry.bik";
+
+// STRING: STRONGHOLDCRUSADER 0x005a7c0c
+char const* const s_philip_taunt_bik_005a7c0c = "philip_taunt.bik";
+
+// STRING: STRONGHOLDCRUSADER 0x005a7c20
+char const* const s_bad_arab_anger_bik_005a7c20 = "bad_arab_anger.bik";
+
+// STRING: STRONGHOLDCRUSADER 0x005a7c34
+char const* const s_wf_taunt2_bik_005a7c34 = "wf_taunt2.bik";
+
+// STRING: STRONGHOLDCRUSADER 0x005a7c44
+char const* const s_pg_taunt2_bik_005a7c44 = "pg_taunt2.bik";
+
+// STRING: STRONGHOLDCRUSADER 0x005a7c54
+char const* const s_sn_taunt2_bik_005a7c54 = "sn_taunt2.bik";
+
+// STRING: STRONGHOLDCRUSADER 0x005a7c64
+char const* const s_rt_taunt1_bik_005a7c64 = "rt_taunt1.bik";
+
+// STRING: STRONGHOLDCRUSADER 0x005a7c74
+char const* const s_abbot_confident_bik_005a7c74 = "abbot_confident.bik";
+
+// STRING: STRONGHOLDCRUSADER 0x005a7c88
+char const* const s_ma_taunt_bik_005a7c88 = "ma_taunt.bik";
+
+// STRING: STRONGHOLDCRUSADER 0x005a7c98
+char const* const s_sheriff_taunt_bik_005a7c98 = "sheriff_taunt.bik";
+
+// STRING: STRONGHOLDCRUSADER 0x005a7cac
+char const* const s_nazir_angry_bik_005a7cac = "nazir_angry.bik";
+
+// STRING: STRONGHOLDCRUSADER 0x005a7cbc
+char const* const s_emir_taunt_bik_005a7cbc = "emir_taunt.bik";
+
+// STRING: STRONGHOLDCRUSADER 0x005a7ccc
+char const* const s_vizir_taunt_bik_005a7ccc = "vizir_taunt.bik";
+
+// STRING: STRONGHOLDCRUSADER 0x005a7cdc
+char const* const s_philip_natural_bik_005a7cdc = "philip_natural.bik";
+
+// STRING: STRONGHOLDCRUSADER 0x005a7cf0
+char const* const s_fred_taunt_bik_005a7cf0 = "fred_taunt.bik";
+
+// STRING: STRONGHOLDCRUSADER 0x005a7d00
+char const* const s_richard_taunting_bik_005a7d00 = "richard_taunting.bik";
+
+// STRING: STRONGHOLDCRUSADER 0x005a7d18
+char const* const s_sultan_taunt_bik_005a7d18 = "sultan_taunt.bik";
+
+// STRING: STRONGHOLDCRUSADER 0x005a7d2c
+char const* const s_bad_arab_taunt_bik_005a7d2c = "bad_arab_taunt.bik";
+
+// STRING: STRONGHOLDCRUSADER 0x005a7d40
+char const* const s_saladin_taunting_bik_005a7d40 = "saladin_taunting.bik";
+
+// STRING: STRONGHOLDCRUSADER 0x005a7d58
+char const* const s_wf_taunt1_bik_005a7d58 = "wf_taunt1.bik";
+
+// STRING: STRONGHOLDCRUSADER 0x005a7d68
+char const* const s_pg_taunt1_bik_005a7d68 = "pg_taunt1.bik";
+
+// STRING: STRONGHOLDCRUSADER 0x005a7d78
+char const* const s_sn_taunt1_bik_005a7d78 = "sn_taunt1.bik";
+
+// STRING: STRONGHOLDCRUSADER 0x005a7d88
+char const* const s_rt_taunt2_bik_005a7d88 = "rt_taunt2.bik";
+
+// STRING: STRONGHOLDCRUSADER 0x005a7d98
+char const* const s_null_bik_005a7d98 = "null.bik";
+
+// STRING: STRONGHOLDCRUSADER 0x005a7da4
+char const* const s_ab_willattack_01_wav_005a7da4 = "ab_willattack_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a7dbc
+char const* const s_ma_willattack_01_wav_005a7dbc = "ma_willattack_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a7dd4
+char const* const s_sh_willattack_01_wav_005a7dd4 = "sh_willattack_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a7dec
+char const* const s_ni_willattack_01_wav_005a7dec = "ni_willattack_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a7e04
+char const* const s_em_willattack_01_wav_005a7e04 = "em_willattack_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a7e1c
+char const* const s_wa_willattack_01_wav_005a7e1c = "wa_willattack_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a7e34
+char const* const s_ph_willattack_01_wav_005a7e34 = "ph_willattack_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a7e4c
+char const* const s_fr_willattack_01_wav_005a7e4c = "fr_willattack_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a7e64
+char const* const s_ri_willattack_01_wav_005a7e64 = "ri_willattack_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a7e7c
+char const* const s_su_willattack_01_wav_005a7e7c = "su_willattack_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a7e94
+char const* const s_ca_willattack_01_wav_005a7e94 = "ca_willattack_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a7eac
+char const* const s_sa_willattack_01_wav_005a7eac = "sa_willattack_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a7ec4
+char const* const s_all_willattack_01_wav_005a7ec4 = "all_willattack_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a7edc
+char const* const s_ab_helpsent_01_wav_005a7edc = "ab_helpsent_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a7ef0
+char const* const s_ma_helpsent_01_wav_005a7ef0 = "ma_helpsent_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a7f04
+char const* const s_sh_helpsent_01_wav_005a7f04 = "sh_helpsent_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a7f18
+char const* const s_ni_helpsent_01_wav_005a7f18 = "ni_helpsent_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a7f2c
+char const* const s_em_helpsent_01_wav_005a7f2c = "em_helpsent_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a7f40
+char const* const s_wa_helpsent_01_wav_005a7f40 = "wa_helpsent_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a7f54
+char const* const s_ph_helpsent_01_wav_005a7f54 = "ph_helpsent_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a7f68
+char const* const s_fr_helpsent_01_wav_005a7f68 = "fr_helpsent_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a7f7c
+char const* const s_ri_helpsent_01_wav_005a7f7c = "ri_helpsent_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a7f90
+char const* const s_su_helpsent_01_wav_005a7f90 = "su_helpsent_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a7fa4
+char const* const s_ca_helpsent_01_wav_005a7fa4 = "ca_helpsent_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a7fb8
+char const* const s_sa_helpsent_01_wav_005a7fb8 = "sa_helpsent_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a7fcc
+char const* const s_all_helpsent_01_wav_005a7fcc = "all_helpsent_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a7fe0
+char const* const s_ab_team_losing_01_wav_005a7fe0 = "ab_team_losing_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a7ff8
+char const* const s_ma_team_losing_01_wav_005a7ff8 = "ma_team_losing_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a8010
+char const* const s_sh_team_losing_01_wav_005a8010 = "sh_team_losing_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a8028
+char const* const s_ni_team_losing_01_wav_005a8028 = "ni_team_losing_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a8040
+char const* const s_em_team_losing_01_wav_005a8040 = "em_team_losing_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a8058
+char const* const s_wa_team_losing_01_wav_005a8058 = "wa_team_losing_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a8070
+char const* const s_ph_team_losing_01_wav_005a8070 = "ph_team_losing_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a8088
+char const* const s_fr_team_losing_01_wav_005a8088 = "fr_team_losing_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a80a0
+char const* const s_ri_team_losing_01_wav_005a80a0 = "ri_team_losing_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a80b8
+char const* const s_su_team_losing_01_wav_005a80b8 = "su_team_losing_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a80d0
+char const* const s_ca_team_losing_01_wav_005a80d0 = "ca_team_losing_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a80e8
+char const* const s_sa_team_losing_01_wav_005a80e8 = "sa_team_losing_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a8100
+char const* const s_all_team_losing_01_wav_005a8100 = "all_team_losing_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a8118
+char const* const s_ab_team_winning_01_wav_005a8118 = "ab_team_winning_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a8130
+char const* const s_ma_team_winning_01_wav_005a8130 = "ma_team_winning_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a8148
+char const* const s_sh_team_winning_01_wav_005a8148 = "sh_team_winning_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a8160
+char const* const s_ni_team_winning_01_wav_005a8160 = "ni_team_winning_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a8178
+char const* const s_em_team_winning_01_wav_005a8178 = "em_team_winning_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a8190
+char const* const s_wa_team_winning_01_wav_005a8190 = "wa_team_winning_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a81a8
+char const* const s_ph_team_winning_01_wav_005a81a8 = "ph_team_winning_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a81c0
+char const* const s_fr_team_winning_01_wav_005a81c0 = "fr_team_winning_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a81d8
+char const* const s_ri_team_winning_01_wav_005a81d8 = "ri_team_winning_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a81f0
+char const* const s_su_team_winning_01_wav_005a81f0 = "su_team_winning_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a8208
+char const* const s_ca_team_winning_01_wav_005a8208 = "ca_team_winning_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a8220
+char const* const s_sa_team_winning_01_wav_005a8220 = "sa_team_winning_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a8238
+char const* const s_all_team_winning_01_wav_005a8238 = "all_team_winning_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a8250
+char const* const s_ab_sent_01_wav_005a8250 = "ab_sent_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a8260
+char const* const s_ma_sent_01_wav_005a8260 = "ma_sent_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a8270
+char const* const s_sh_sent_01_wav_005a8270 = "sh_sent_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a8280
+char const* const s_ni_sent_01_wav_005a8280 = "ni_sent_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a8290
+char const* const s_em_sent_01_wav_005a8290 = "em_sent_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a82a0
+char const* const s_wa_sent_01_wav_005a82a0 = "wa_sent_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a82b0
+char const* const s_ph_sent_01_wav_005a82b0 = "ph_sent_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a82c0
+char const* const s_fr_sent_01_wav_005a82c0 = "fr_sent_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a82d0
+char const* const s_ri_sent_01_wav_005a82d0 = "ri_sent_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a82e0
+char const* const s_su_sent_01_wav_005a82e0 = "su_sent_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a82f0
+char const* const s_ca_sent_01_wav_005a82f0 = "ca_sent_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a8300
+char const* const s_sa_sent_01_wav_005a8300 = "sa_sent_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a8310
+char const* const s_all_sent_01_wav_005a8310 = "all_sent_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a8320
+char const* const s_ab_notsent_01_wav_005a8320 = "ab_notsent_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a8334
+char const* const s_ma_notsent_01_wav_005a8334 = "ma_notsent_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a8348
+char const* const s_sh_notsent_01_wav_005a8348 = "sh_notsent_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a835c
+char const* const s_ni_notsent_01_wav_005a835c = "ni_notsent_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a8370
+char const* const s_em_notsent_01_wav_005a8370 = "em_notsent_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a8384
+char const* const s_wa_notsent_01_wav_005a8384 = "wa_notsent_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a8398
+char const* const s_ph_notsent_01_wav_005a8398 = "ph_notsent_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a83ac
+char const* const s_fr_notsent_01_wav_005a83ac = "fr_notsent_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a83c0
+char const* const s_ri_notsent_01_wav_005a83c0 = "ri_notsent_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a83d4
+char const* const s_su_notsent_01_wav_005a83d4 = "su_notsent_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a83e8
+char const* const s_ca_notsent_01_wav_005a83e8 = "ca_notsent_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a83fc
+char const* const s_sa_notsent_01_wav_005a83fc = "sa_notsent_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a8410
+char const* const s_all_notsent_01_wav_005a8410 = "all_notsent_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a8424
+char const* const s_ab_nohelp_02_wav_005a8424 = "ab_nohelp_02.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a8438
+char const* const s_ma_nohelp_02_wav_005a8438 = "ma_nohelp_02.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a844c
+char const* const s_sh_nohelp_02_wav_005a844c = "sh_nohelp_02.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a8460
+char const* const s_ni_nohelp_02_wav_005a8460 = "ni_nohelp_02.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a8474
+char const* const s_em_nohelp_02_wav_005a8474 = "em_nohelp_02.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a8488
+char const* const s_wa_nohelp_02_wav_005a8488 = "wa_nohelp_02.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a849c
+char const* const s_ph_nohelp_02_wav_005a849c = "ph_nohelp_02.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a84b0
+char const* const s_fr_nohelp_02_wav_005a84b0 = "fr_nohelp_02.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a84c4
+char const* const s_ri_nohelp_02_wav_005a84c4 = "ri_nohelp_02.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a84d8
+char const* const s_su_nohelp_02_wav_005a84d8 = "su_nohelp_02.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a84ec
+char const* const s_ca_nohelp_02_wav_005a84ec = "ca_nohelp_02.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a8500
+char const* const s_sa_nohelp_02_wav_005a8500 = "sa_nohelp_02.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a8514
+char const* const s_all_nohelp_02_wav_005a8514 = "all_nohelp_02.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a8528
+char const* const s_ab_nohelp_01_wav_005a8528 = "ab_nohelp_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a853c
+char const* const s_ma_nohelp_01_wav_005a853c = "ma_nohelp_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a8550
+char const* const s_sh_nohelp_01_wav_005a8550 = "sh_nohelp_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a8564
+char const* const s_ni_nohelp_01_wav_005a8564 = "ni_nohelp_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a8578
+char const* const s_em_nohelp_01_wav_005a8578 = "em_nohelp_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a858c
+char const* const s_wa_nohelp_01_wav_005a858c = "wa_nohelp_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a85a0
+char const* const s_ph_nohelp_01_wav_005a85a0 = "ph_nohelp_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a85b4
+char const* const s_fr_nohelp_01_wav_005a85b4 = "fr_nohelp_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a85c8
+char const* const s_ri_nohelp_01_wav_005a85c8 = "ri_nohelp_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a85dc
+char const* const s_su_nohelp_01_wav_005a85dc = "su_nohelp_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a85f0
+char const* const s_ca_nohelp_01_wav_005a85f0 = "ca_nohelp_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a8604
+char const* const s_sa_nohelp_01_wav_005a8604 = "sa_nohelp_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a8618
+char const* const s_all_nohelp_01_wav_005a8618 = "all_nohelp_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a862c
+char const* const s_ab_noattack_02_wav_005a862c = "ab_noattack_02.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a8640
+char const* const s_ma_noattack_02_wav_005a8640 = "ma_noattack_02.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a8654
+char const* const s_sh_noattack_02_wav_005a8654 = "sh_noattack_02.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a8668
+char const* const s_ni_noattack_02_wav_005a8668 = "ni_noattack_02.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a867c
+char const* const s_em_noattack_02_wav_005a867c = "em_noattack_02.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a8690
+char const* const s_wa_noattack_02_wav_005a8690 = "wa_noattack_02.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a86a4
+char const* const s_ph_noattack_02_wav_005a86a4 = "ph_noattack_02.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a86b8
+char const* const s_fr_noattack_02_wav_005a86b8 = "fr_noattack_02.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a86cc
+char const* const s_ri_noattack_02_wav_005a86cc = "ri_noattack_02.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a86e0
+char const* const s_su_noattack_02_wav_005a86e0 = "su_noattack_02.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a86f4
+char const* const s_ca_noattack_02_wav_005a86f4 = "ca_noattack_02.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a8708
+char const* const s_sa_noattack_02_wav_005a8708 = "sa_noattack_02.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a871c
+char const* const s_all_noattack_02_wav_005a871c = "all_noattack_02.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a8730
+char const* const s_ab_noattack_01_wav_005a8730 = "ab_noattack_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a8744
+char const* const s_ma_noattack_01_wav_005a8744 = "ma_noattack_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a8758
+char const* const s_sh_noattack_01_wav_005a8758 = "sh_noattack_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a876c
+char const* const s_ni_noattack_01_wav_005a876c = "ni_noattack_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a8780
+char const* const s_em_noattack_01_wav_005a8780 = "em_noattack_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a8794
+char const* const s_wa_noattack_01_wav_005a8794 = "wa_noattack_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a87a8
+char const* const s_ph_noattack_01_wav_005a87a8 = "ph_noattack_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a87bc
+char const* const s_fr_noattack_01_wav_005a87bc = "fr_noattack_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a87d0
+char const* const s_ri_noattack_01_wav_005a87d0 = "ri_noattack_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a87e4
+char const* const s_su_noattack_01_wav_005a87e4 = "su_noattack_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a87f8
+char const* const s_ca_noattack_01_wav_005a87f8 = "ca_noattack_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a880c
+char const* const s_sa_noattack_01_wav_005a880c = "sa_noattack_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a8820
+char const* const s_all_noattack_01_wav_005a8820 = "all_noattack_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a8834
+char const* const s_ab_siege_01_wav_005a8834 = "ab_siege_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a8844
+char const* const s_ma_siege_01_wav_005a8844 = "ma_siege_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a8854
+char const* const s_sh_siege_01_wav_005a8854 = "sh_siege_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a8864
+char const* const s_ni_siege_01_wav_005a8864 = "ni_siege_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a8874
+char const* const s_em_siege_01_wav_005a8874 = "em_siege_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a8884
+char const* const s_wa_siege_01_wav_005a8884 = "wa_siege_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a8894
+char const* const s_ph_siege_01_wav_005a8894 = "ph_siege_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a88a4
+char const* const s_fr_siege_01_wav_005a88a4 = "fr_siege_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a88b4
+char const* const s_ri_siege_01_wav_005a88b4 = "ri_siege_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a88c4
+char const* const s_su_siege_01_wav_005a88c4 = "su_siege_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a88d4
+char const* const s_ca_siege_01_wav_005a88d4 = "ca_siege_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a88e4
+char const* const s_sa_siege_01_wav_005a88e4 = "sa_siege_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a88f4
+char const* const s_all_siege_01_wav_005a88f4 = "all_siege_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a8908
+char const* const s_ab_add_player_01_wav_005a8908 = "ab_add_player_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a8920
+char const* const s_ma_add_player_01_wav_005a8920 = "ma_add_player_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a8938
+char const* const s_sh_add_player_01_wav_005a8938 = "sh_add_player_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a8950
+char const* const s_ni_add_player_01_wav_005a8950 = "ni_add_player_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a8968
+char const* const s_em_add_player_01_wav_005a8968 = "em_add_player_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a8980
+char const* const s_wa_add_player_01_wav_005a8980 = "wa_add_player_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a8998
+char const* const s_ph_add_player_01_wav_005a8998 = "ph_add_player_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a89b0
+char const* const s_fr_add_player_01_wav_005a89b0 = "fr_add_player_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a89c8
+char const* const s_ri_add_player_01_wav_005a89c8 = "ri_add_player_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a89e0
+char const* const s_su_add_player_01_wav_005a89e0 = "su_add_player_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a89f8
+char const* const s_ca_add_player_01_wav_005a89f8 = "ca_add_player_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a8a10
+char const* const s_sa_add_player_01_wav_005a8a10 = "sa_add_player_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a8a28
+char const* const s_wf_add_player_wav_005a8a28 = "wf_add_player.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a8a3c
+char const* const s_pg_add_player_wav_005a8a3c = "pg_add_player.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a8a50
+char const* const s_sn_add_player_wav_005a8a50 = "sn_add_player.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a8a64
+char const* const s_rt_add_player_wav_005a8a64 = "rt_add_player.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a8a78
+char const* const s_all_add_player_01_wav_005a8a78 = "all_add_player_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a8a90
+char const* const s_ab_kick_player_01_wav_005a8a90 = "ab_kick_player_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a8aa8
+char const* const s_ma_kick_player_01_wav_005a8aa8 = "ma_kick_player_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a8ac0
+char const* const s_sh_kick_player_01_wav_005a8ac0 = "sh_kick_player_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a8ad8
+char const* const s_ni_kick_player_01_wav_005a8ad8 = "ni_kick_player_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a8af0
+char const* const s_em_kick_player_01_wav_005a8af0 = "em_kick_player_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a8b08
+char const* const s_wa_kick_player_01_wav_005a8b08 = "wa_kick_player_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a8b20
+char const* const s_ph_kick_player_01_wav_005a8b20 = "ph_kick_player_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a8b38
+char const* const s_fr_kick_player_01_wav_005a8b38 = "fr_kick_player_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a8b50
+char const* const s_ri_kick_player_01_wav_005a8b50 = "ri_kick_player_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a8b68
+char const* const s_su_kick_player_01_wav_005a8b68 = "su_kick_player_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a8b80
+char const* const s_ca_kick_player_01_wav_005a8b80 = "ca_kick_player_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a8b98
+char const* const s_sa_kick_player_01_wav_005a8b98 = "sa_kick_player_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a8bb0
+char const* const s_wf_kick_player_wav_005a8bb0 = "wf_kick_player.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a8bc4
+char const* const s_pg_kick_player_wav_005a8bc4 = "pg_kick_player.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a8bd8
+char const* const s_sn_kick_player_wav_005a8bd8 = "sn_kick_player.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a8bec
+char const* const s_rt_kick_player_wav_005a8bec = "rt_kick_player.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a8c00
+char const* const s_all_kick_player_01_wav_005a8c00 = "all_kick_player_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a8c18
+char const* const s_ab_extra_01_wav_005a8c18 = "ab_extra_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a8c28
+char const* const s_ma_extra_01_wav_005a8c28 = "ma_extra_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a8c38
+char const* const s_sh_extra_01_wav_005a8c38 = "sh_extra_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a8c48
+char const* const s_ni_extra_01_wav_005a8c48 = "ni_extra_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a8c58
+char const* const s_em_extra_01_wav_005a8c58 = "em_extra_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a8c68
+char const* const s_wa_extra_01_wav_005a8c68 = "wa_extra_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a8c78
+char const* const s_ph_extra_01_wav_005a8c78 = "ph_extra_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a8c88
+char const* const s_fr_extra_01_wav_005a8c88 = "fr_extra_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a8c98
+char const* const s_ri_extra_01_wav_005a8c98 = "ri_extra_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a8ca8
+char const* const s_su_extra_01_wav_005a8ca8 = "su_extra_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a8cb8
+char const* const s_ca_extra_01_wav_005a8cb8 = "ca_extra_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a8cc8
+char const* const s_sa_extra_01_wav_005a8cc8 = "sa_extra_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a8cd8
+char const* const s_all_extra_01_wav_005a8cd8 = "all_extra_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a8cec
+char const* const s_ab_help_01_wav_005a8cec = "ab_help_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a8cfc
+char const* const s_ma_help_01_wav_005a8cfc = "ma_help_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a8d0c
+char const* const s_sh_help_01_wav_005a8d0c = "sh_help_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a8d1c
+char const* const s_ni_help_01_wav_005a8d1c = "ni_help_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a8d2c
+char const* const s_em_help_01_wav_005a8d2c = "em_help_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a8d3c
+char const* const s_wa_help_01_wav_005a8d3c = "wa_help_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a8d4c
+char const* const s_ph_help_01_wav_005a8d4c = "ph_help_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a8d5c
+char const* const s_fr_help_01_wav_005a8d5c = "fr_help_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a8d6c
+char const* const s_ri_help_01_wav_005a8d6c = "ri_help_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a8d7c
+char const* const s_su_help_01_wav_005a8d7c = "su_help_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a8d8c
+char const* const s_ca_help_01_wav_005a8d8c = "ca_help_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a8d9c
+char const* const s_sa_help_01_wav_005a8d9c = "sa_help_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a8dac
+char const* const s_all_help_01_wav_005a8dac = "all_help_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a8dbc
+char const* const s_ab_boast_01_wav_005a8dbc = "ab_boast_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a8dcc
+char const* const s_ma_boast_01_wav_005a8dcc = "ma_boast_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a8ddc
+char const* const s_sh_boast_01_wav_005a8ddc = "sh_boast_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a8dec
+char const* const s_ni_boast_01_wav_005a8dec = "ni_boast_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a8dfc
+char const* const s_em_boast_01_wav_005a8dfc = "em_boast_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a8e0c
+char const* const s_wa_boast_01_wav_005a8e0c = "wa_boast_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a8e1c
+char const* const s_ph_boast_01_wav_005a8e1c = "ph_boast_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a8e2c
+char const* const s_fr_boast_01_wav_005a8e2c = "fr_boast_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a8e3c
+char const* const s_ri_boast_01_wav_005a8e3c = "ri_boast_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a8e4c
+char const* const s_su_boast_01_wav_005a8e4c = "su_boast_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a8e5c
+char const* const s_ca_boast_01_wav_005a8e5c = "ca_boast_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a8e6c
+char const* const s_sa_boast_01_wav_005a8e6c = "sa_boast_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a8e7c
+char const* const s_all_boast_01_wav_005a8e7c = "all_boast_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a8e90
+char const* const s_ab_congrats_01_wav_005a8e90 = "ab_congrats_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a8ea4
+char const* const s_ma_congrats_01_wav_005a8ea4 = "ma_congrats_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a8eb8
+char const* const s_sh_congrats_01_wav_005a8eb8 = "sh_congrats_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a8ecc
+char const* const s_ni_congrats_01_wav_005a8ecc = "ni_congrats_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a8ee0
+char const* const s_em_congrats_01_wav_005a8ee0 = "em_congrats_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a8ef4
+char const* const s_wa_congrats_01_wav_005a8ef4 = "wa_congrats_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a8f08
+char const* const s_ph_congrats_01_wav_005a8f08 = "ph_congrats_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a8f1c
+char const* const s_fr_congrats_01_wav_005a8f1c = "fr_congrats_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a8f30
+char const* const s_ri_congrats_01_wav_005a8f30 = "ri_congrats_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a8f44
+char const* const s_su_congrats_01_wav_005a8f44 = "su_congrats_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a8f58
+char const* const s_ca_congrats_01_wav_005a8f58 = "ca_congrats_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a8f6c
+char const* const s_sa_congrats_01_wav_005a8f6c = "sa_congrats_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a8f80
+char const* const s_all_congrats_01_wav_005a8f80 = "all_congrats_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a8f94
+char const* const s_ab_ally_death_01_wav_005a8f94 = "ab_ally_death_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a8fac
+char const* const s_ma_ally_death_01_wav_005a8fac = "ma_ally_death_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a8fc4
+char const* const s_sh_ally_death_01_wav_005a8fc4 = "sh_ally_death_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a8fdc
+char const* const s_ni_ally_death_01_wav_005a8fdc = "ni_ally_death_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a8ff4
+char const* const s_em_ally_death_01_wav_005a8ff4 = "em_ally_death_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a900c
+char const* const s_wa_ally_death_01_wav_005a900c = "wa_ally_death_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a9024
+char const* const s_ph_ally_death_01_wav_005a9024 = "ph_ally_death_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a903c
+char const* const s_fr_ally_death_01_wav_005a903c = "fr_ally_death_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a9054
+char const* const s_ri_ally_death_01_wav_005a9054 = "ri_ally_death_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a906c
+char const* const s_su_ally_death_01_wav_005a906c = "su_ally_death_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a9084
+char const* const s_ca_ally_death_01_wav_005a9084 = "ca_ally_death_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a909c
+char const* const s_sa_ally_death_01_wav_005a909c = "sa_ally_death_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a90b4
+char const* const s_pg_plead_02_wav_005a90b4 = "pg_plead_02.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a90c4
+char const* const s_rt_anger_02_wav_005a90c4 = "rt_anger_02.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a90d4
+char const* const s_all_ally_death_01_wav_005a90d4 = "all_ally_death_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a90ec
+char const* const s_ab_thanks_01_wav_005a90ec = "ab_thanks_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a9100
+char const* const s_ma_thanks_01_wav_005a9100 = "ma_thanks_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a9114
+char const* const s_sh_thanks_01_wav_005a9114 = "sh_thanks_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a9128
+char const* const s_ni_thanks_01_wav_005a9128 = "ni_thanks_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a913c
+char const* const s_em_thanks_01_wav_005a913c = "em_thanks_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a9150
+char const* const s_wa_thanks_01_wav_005a9150 = "wa_thanks_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a9164
+char const* const s_ph_thanks_01_wav_005a9164 = "ph_thanks_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a9178
+char const* const s_fr_thanks_01_wav_005a9178 = "fr_thanks_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a918c
+char const* const s_ri_thanks_01_wav_005a918c = "ri_thanks_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a91a0
+char const* const s_su_thanks_01_wav_005a91a0 = "su_thanks_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a91b4
+char const* const s_ca_thanks_01_wav_005a91b4 = "ca_thanks_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a91c8
+char const* const s_sa_thanks_01_wav_005a91c8 = "sa_thanks_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a91dc
+char const* const s_all_thanks_01_wav_005a91dc = "all_thanks_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a91f0
+char const* const s_ab_req_01_wav_005a91f0 = "ab_req_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a9200
+char const* const s_ma_req_01_wav_005a9200 = "ma_req_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a9210
+char const* const s_sh_req_01_wav_005a9210 = "sh_req_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a9220
+char const* const s_ni_req_01_wav_005a9220 = "ni_req_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a9230
+char const* const s_em_req_01_wav_005a9230 = "em_req_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a9240
+char const* const s_wa_req_01_wav_005a9240 = "wa_req_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a9250
+char const* const s_ph_req_01_wav_005a9250 = "ph_req_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a9260
+char const* const s_fr_req_01_wav_005a9260 = "fr_req_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a9270
+char const* const s_ri_req_01_wav_005a9270 = "ri_req_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a9280
+char const* const s_su_req_01_wav_005a9280 = "su_req_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a9290
+char const* const s_ca_req_01_wav_005a9290 = "ca_req_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a92a0
+char const* const s_sa_req_01_wav_005a92a0 = "sa_req_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a92b0
+char const* const s_all_req_01_wav_005a92b0 = "all_req_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a92c0
+char const* const s_ab_vict_04_wav_005a92c0 = "ab_vict_04.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a92d0
+char const* const s_ma_vict_04_wav_005a92d0 = "ma_vict_04.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a92e0
+char const* const s_sh_vict_04_wav_005a92e0 = "sh_vict_04.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a92f0
+char const* const s_ni_vict_04_wav_005a92f0 = "ni_vict_04.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a9300
+char const* const s_em_vict_04_wav_005a9300 = "em_vict_04.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a9310
+char const* const s_wa_vict_04_wav_005a9310 = "wa_vict_04.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a9320
+char const* const s_ph_vict_04_wav_005a9320 = "ph_vict_04.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a9330
+char const* const s_fr_vict_04_wav_005a9330 = "fr_vict_04.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a9340
+char const* const s_ri_vict_04_wav_005a9340 = "ri_vict_04.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a9350
+char const* const s_su_vict_04_wav_005a9350 = "su_vict_04.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a9360
+char const* const s_ca_vict_04_wav_005a9360 = "ca_vict_04.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a9370
+char const* const s_sa_vict_04_wav_005a9370 = "sa_vict_04.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a9380
+char const* const s_pg_taunt_02_wav_005a9380 = "pg_taunt_02.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a9390
+char const* const s_sn_vict_04_wav_005a9390 = "sn_vict_04.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a93a0
+char const* const s_rt_vict_03_wav_005a93a0 = "rt_vict_03.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a93b0
+char const* const s_all_vict_04_wav_005a93b0 = "all_vict_04.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a93c0
+char const* const s_ab_vict_03_wav_005a93c0 = "ab_vict_03.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a93d0
+char const* const s_ma_vict_03_wav_005a93d0 = "ma_vict_03.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a93e0
+char const* const s_sh_vict_03_wav_005a93e0 = "sh_vict_03.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a93f0
+char const* const s_ni_vict_03_wav_005a93f0 = "ni_vict_03.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a9400
+char const* const s_em_vict_03_wav_005a9400 = "em_vict_03.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a9410
+char const* const s_wa_vict_03_wav_005a9410 = "wa_vict_03.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a9420
+char const* const s_ph_vict_03_wav_005a9420 = "ph_vict_03.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a9430
+char const* const s_fr_vict_03_wav_005a9430 = "fr_vict_03.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a9440
+char const* const s_ri_vict_03_wav_005a9440 = "ri_vict_03.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a9450
+char const* const s_su_vict_03_wav_005a9450 = "su_vict_03.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a9460
+char const* const s_ca_vict_03_wav_005a9460 = "ca_vict_03.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a9470
+char const* const s_sa_vict_03_wav_005a9470 = "sa_vict_03.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a9480
+char const* const s_wf_vict_01_wav_005a9480 = "wf_vict_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a9490
+char const* const s_pg_vict_03_wav_005a9490 = "pg_vict_03.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a94a0
+char const* const s_sn_vict_03_wav_005a94a0 = "sn_vict_03.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a94b0
+char const* const s_rt_vict_04_wav_005a94b0 = "rt_vict_04.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a94c0
+char const* const s_all_vict_03_wav_005a94c0 = "all_vict_03.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a94d0
+char const* const s_ab_vict_02_wav_005a94d0 = "ab_vict_02.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a94e0
+char const* const s_ma_vict_02_wav_005a94e0 = "ma_vict_02.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a94f0
+char const* const s_sh_vict_02_wav_005a94f0 = "sh_vict_02.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a9500
+char const* const s_ni_vict_02_wav_005a9500 = "ni_vict_02.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a9510
+char const* const s_em_vict_02_wav_005a9510 = "em_vict_02.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a9520
+char const* const s_wa_vict_02_wav_005a9520 = "wa_vict_02.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a9530
+char const* const s_ph_vict_02_wav_005a9530 = "ph_vict_02.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a9540
+char const* const s_fr_vict_02_wav_005a9540 = "fr_vict_02.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a9550
+char const* const s_ri_vict_02_wav_005a9550 = "ri_vict_02.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a9560
+char const* const s_su_vict_02_wav_005a9560 = "su_vict_02.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a9570
+char const* const s_ca_vict_02_wav_005a9570 = "ca_vict_02.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a9580
+char const* const s_sa_vict_02_wav_005a9580 = "sa_vict_02.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a9590
+char const* const s_wf_taunt_04_wav_005a9590 = "wf_taunt_04.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a95a0
+char const* const s_pg_vict_02_wav_005a95a0 = "pg_vict_02.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a95b0
+char const* const s_sn_taunt_03_wav_005a95b0 = "sn_taunt_03.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a95c0
+char const* const s_rt_vict_02_wav_005a95c0 = "rt_vict_02.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a95d0
+char const* const s_all_vict_02_wav_005a95d0 = "all_vict_02.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a95e0
+char const* const s_ab_vict_01_wav_005a95e0 = "ab_vict_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a95f0
+char const* const s_ma_vict_01_wav_005a95f0 = "ma_vict_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a9600
+char const* const s_sh_vict_01_wav_005a9600 = "sh_vict_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a9610
+char const* const s_ni_vict_01_wav_005a9610 = "ni_vict_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a9620
+char const* const s_em_vict_01_wav_005a9620 = "em_vict_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a9630
+char const* const s_wa_vict_01_wav_005a9630 = "wa_vict_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a9640
+char const* const s_ph_vict_01_wav_005a9640 = "ph_vict_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a9650
+char const* const s_fr_vict_01_wav_005a9650 = "fr_vict_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a9660
+char const* const s_ri_vict_01_wav_005a9660 = "ri_vict_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a9670
+char const* const s_su_vict_01_wav_005a9670 = "su_vict_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a9680
+char const* const s_ca_vict_01_wav_005a9680 = "ca_vict_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a9690
+char const* const s_sa_vict_01_wav_005a9690 = "sa_vict_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a96a0
+char const* const s_wf_vict_02_wav_005a96a0 = "wf_vict_02.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a96b0
+char const* const s_pg_vict_01_wav_005a96b0 = "pg_vict_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a96c0
+char const* const s_sn_vict_02_wav_005a96c0 = "sn_vict_02.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a96d0
+char const* const s_rt_vict_01_wav_005a96d0 = "rt_vict_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a96e0
+char const* const s_all_vict_01_wav_005a96e0 = "all_vict_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a96f0
+char const* const s_ab_nervous_02_wav_005a96f0 = "ab_nervous_02.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a9704
+char const* const s_ma_nervous_02_wav_005a9704 = "ma_nervous_02.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a9718
+char const* const s_sh_nervous_02_wav_005a9718 = "sh_nervous_02.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a972c
+char const* const s_ni_nervous_02_wav_005a972c = "ni_nervous_02.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a9740
+char const* const s_em_nervous_02_wav_005a9740 = "em_nervous_02.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a9754
+char const* const s_wa_nervous_02_wav_005a9754 = "wa_nervous_02.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a9768
+char const* const s_ph_nervous_02_wav_005a9768 = "ph_nervous_02.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a977c
+char const* const s_fr_nervous_02_wav_005a977c = "fr_nervous_02.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a9790
+char const* const s_ri_nervous_02_wav_005a9790 = "ri_nervous_02.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a97a4
+char const* const s_su_nervous_02_wav_005a97a4 = "su_nervous_02.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a97b8
+char const* const s_ca_nervous_02_wav_005a97b8 = "ca_nervous_02.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a97cc
+char const* const s_sa_nervous_02_wav_005a97cc = "sa_nervous_02.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a97e0
+char const* const s_wf_plead_04_wav_005a97e0 = "wf_plead_04.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a97f0
+char const* const s_pg_plead_04_wav_005a97f0 = "pg_plead_04.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a9800
+char const* const s_sn_plead_03_wav_005a9800 = "sn_plead_03.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a9810
+char const* const s_rt_plead_03_wav_005a9810 = "rt_plead_03.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a9820
+char const* const s_all_plead_03_wav_005a9820 = "all_plead_03.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a9834
+char const* const s_ab_nervous_01_wav_005a9834 = "ab_nervous_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a9848
+char const* const s_ma_nervous_01_wav_005a9848 = "ma_nervous_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a985c
+char const* const s_sh_nervous_01_wav_005a985c = "sh_nervous_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a9870
+char const* const s_ni_nervous_01_wav_005a9870 = "ni_nervous_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a9884
+char const* const s_em_nervous_01_wav_005a9884 = "em_nervous_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a9898
+char const* const s_wa_nervous_01_wav_005a9898 = "wa_nervous_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a98ac
+char const* const s_ph_nervous_01_wav_005a98ac = "ph_nervous_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a98c0
+char const* const s_fr_nervous_01_wav_005a98c0 = "fr_nervous_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a98d4
+char const* const s_ri_nervous_01_wav_005a98d4 = "ri_nervous_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a98e8
+char const* const s_su_nervous_01_wav_005a98e8 = "su_nervous_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a98fc
+char const* const s_ca_nervous_01_wav_005a98fc = "ca_nervous_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a9910
+char const* const s_sa_nervous_01_wav_005a9910 = "sa_nervous_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a9924
+char const* const s_wf_plead_03_wav_005a9924 = "wf_plead_03.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a9934
+char const* const s_pg_plead_03_wav_005a9934 = "pg_plead_03.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a9944
+char const* const s_sn_plead_04_wav_005a9944 = "sn_plead_04.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a9954
+char const* const s_rt_plead_04_wav_005a9954 = "rt_plead_04.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a9964
+char const* const s_all_plead_02_wav_005a9964 = "all_plead_02.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a9978
+char const* const s_ab_plead_01_wav_005a9978 = "ab_plead_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a9988
+char const* const s_ma_plead_01_wav_005a9988 = "ma_plead_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a9998
+char const* const s_sh_plead_01_wav_005a9998 = "sh_plead_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a99a8
+char const* const s_ni_plead_01_wav_005a99a8 = "ni_plead_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a99b8
+char const* const s_em_plead_01_wav_005a99b8 = "em_plead_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a99c8
+char const* const s_wa_plead_01_wav_005a99c8 = "wa_plead_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a99d8
+char const* const s_ph_plead_01_wav_005a99d8 = "ph_plead_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a99e8
+char const* const s_fr_plead_01_wav_005a99e8 = "fr_plead_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a99f8
+char const* const s_ri_plead_01_wav_005a99f8 = "ri_plead_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a9a08
+char const* const s_su_plead_01_wav_005a9a08 = "su_plead_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a9a18
+char const* const s_ca_plead_01_wav_005a9a18 = "ca_plead_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a9a28
+char const* const s_sa_plead_01_wav_005a9a28 = "sa_plead_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a9a38
+char const* const s_wf_plead_01_wav_005a9a38 = "wf_plead_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a9a48
+char const* const s_pg_plead_01_wav_005a9a48 = "pg_plead_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a9a58
+char const* const s_sn_plead_01_wav_005a9a58 = "sn_plead_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a9a68
+char const* const s_rt_plead_01_wav_005a9a68 = "rt_plead_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a9a78
+char const* const s_all_plead_01_wav_005a9a78 = "all_plead_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a9a8c
+char const* const s_ab_anger_02_wav_005a9a8c = "ab_anger_02.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a9a9c
+char const* const s_ma_anger_02_wav_005a9a9c = "ma_anger_02.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a9aac
+char const* const s_sh_anger_02_wav_005a9aac = "sh_anger_02.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a9abc
+char const* const s_ni_anger_02_wav_005a9abc = "ni_anger_02.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a9acc
+char const* const s_em_anger_02_wav_005a9acc = "em_anger_02.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a9adc
+char const* const s_wa_anger_02_wav_005a9adc = "wa_anger_02.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a9aec
+char const* const s_ph_anger_02_wav_005a9aec = "ph_anger_02.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a9afc
+char const* const s_fr_anger_02_wav_005a9afc = "fr_anger_02.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a9b0c
+char const* const s_ri_anger_02_wav_005a9b0c = "ri_anger_02.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a9b1c
+char const* const s_su_anger_02_wav_005a9b1c = "su_anger_02.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a9b2c
+char const* const s_ca_anger_02_wav_005a9b2c = "ca_anger_02.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a9b3c
+char const* const s_sa_anger_02_wav_005a9b3c = "sa_anger_02.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a9b4c
+char const* const s_wf_anger_02_wav_005a9b4c = "wf_anger_02.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a9b5c
+char const* const s_pg_anger_02_wav_005a9b5c = "pg_anger_02.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a9b6c
+char const* const s_sn_anger_04_wav_005a9b6c = "sn_anger_04.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a9b7c
+char const* const s_rt_anger_01_wav_005a9b7c = "rt_anger_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a9b8c
+char const* const s_all_anger_02_wav_005a9b8c = "all_anger_02.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a9ba0
+char const* const s_ab_anger_01_wav_005a9ba0 = "ab_anger_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a9bb0
+char const* const s_ma_anger_01_wav_005a9bb0 = "ma_anger_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a9bc0
+char const* const s_sh_anger_01_wav_005a9bc0 = "sh_anger_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a9bd0
+char const* const s_ni_anger_01_wav_005a9bd0 = "ni_anger_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a9be0
+char const* const s_em_anger_01_wav_005a9be0 = "em_anger_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a9bf0
+char const* const s_wa_anger_01_wav_005a9bf0 = "wa_anger_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a9c00
+char const* const s_ph_anger_01_wav_005a9c00 = "ph_anger_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a9c10
+char const* const s_fr_anger_01_wav_005a9c10 = "fr_anger_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a9c20
+char const* const s_ri_anger_01_wav_005a9c20 = "ri_anger_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a9c30
+char const* const s_su_anger_01_wav_005a9c30 = "su_anger_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a9c40
+char const* const s_ca_anger_01_wav_005a9c40 = "ca_anger_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a9c50
+char const* const s_sa_anger_01_wav_005a9c50 = "sa_anger_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a9c60
+char const* const s_wf_anger_04_wav_005a9c60 = "wf_anger_04.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a9c70
+char const* const s_pg_anger_04_wav_005a9c70 = "pg_anger_04.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a9c80
+char const* const s_sn_anger_03_wav_005a9c80 = "sn_anger_03.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a9c90
+char const* const s_rt_anger_04_wav_005a9c90 = "rt_anger_04.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a9ca0
+char const* const s_all_anger_01_wav_005a9ca0 = "all_anger_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a9cb4
+char const* const s_ab_taunt_04_wav_005a9cb4 = "ab_taunt_04.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a9cc4
+char const* const s_ma_taunt_04_wav_005a9cc4 = "ma_taunt_04.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a9cd4
+char const* const s_sh_taunt_04_wav_005a9cd4 = "sh_taunt_04.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a9ce4
+char const* const s_ni_taunt_04_wav_005a9ce4 = "ni_taunt_04.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a9cf4
+char const* const s_em_taunt_04_wav_005a9cf4 = "em_taunt_04.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a9d04
+char const* const s_wa_taunt_04_wav_005a9d04 = "wa_taunt_04.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a9d14
+char const* const s_ph_taunt_04_wav_005a9d14 = "ph_taunt_04.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a9d24
+char const* const s_fr_taunt_04_wav_005a9d24 = "fr_taunt_04.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a9d34
+char const* const s_ri_taunt_04_wav_005a9d34 = "ri_taunt_04.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a9d44
+char const* const s_su_taunt_04_wav_005a9d44 = "su_taunt_04.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a9d54
+char const* const s_ca_taunt_04_wav_005a9d54 = "ca_taunt_04.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a9d64
+char const* const s_sa_taunt_04_wav_005a9d64 = "sa_taunt_04.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a9d74
+char const* const s_wf_taunt_06_wav_005a9d74 = "wf_taunt_06.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a9d84
+char const* const s_pg_taunt_07_wav_005a9d84 = "pg_taunt_07.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a9d94
+char const* const s_sn_taunt_07_wav_005a9d94 = "sn_taunt_07.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a9da4
+char const* const s_rt_taunt_08_wav_005a9da4 = "rt_taunt_08.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a9db4
+char const* const s_all_taunt_04_wav_005a9db4 = "all_taunt_04.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a9dc8
+char const* const s_ab_taunt_03_wav_005a9dc8 = "ab_taunt_03.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a9dd8
+char const* const s_ma_taunt_03_wav_005a9dd8 = "ma_taunt_03.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a9de8
+char const* const s_sh_taunt_03_wav_005a9de8 = "sh_taunt_03.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a9df8
+char const* const s_ni_taunt_03_wav_005a9df8 = "ni_taunt_03.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a9e08
+char const* const s_em_taunt_03_wav_005a9e08 = "em_taunt_03.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a9e18
+char const* const s_wa_taunt_03_wav_005a9e18 = "wa_taunt_03.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a9e28
+char const* const s_ph_taunt_03_wav_005a9e28 = "ph_taunt_03.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a9e38
+char const* const s_fr_taunt_03_wav_005a9e38 = "fr_taunt_03.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a9e48
+char const* const s_ri_taunt_03_wav_005a9e48 = "ri_taunt_03.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a9e58
+char const* const s_su_taunt_03_wav_005a9e58 = "su_taunt_03.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a9e68
+char const* const s_ca_taunt_03_wav_005a9e68 = "ca_taunt_03.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a9e78
+char const* const s_sa_taunt_03_wav_005a9e78 = "sa_taunt_03.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a9e88
+char const* const s_wf_taunt_05_wav_005a9e88 = "wf_taunt_05.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a9e98
+char const* const s_pg_taunt_06_wav_005a9e98 = "pg_taunt_06.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a9ea8
+char const* const s_sn_taunt_05_wav_005a9ea8 = "sn_taunt_05.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a9eb8
+char const* const s_rt_taunt_05_wav_005a9eb8 = "rt_taunt_05.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a9ec8
+char const* const s_all_taunt_03_wav_005a9ec8 = "all_taunt_03.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a9edc
+char const* const s_ab_taunt_02_wav_005a9edc = "ab_taunt_02.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a9eec
+char const* const s_ma_taunt_02_wav_005a9eec = "ma_taunt_02.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a9efc
+char const* const s_sh_taunt_02_wav_005a9efc = "sh_taunt_02.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a9f0c
+char const* const s_ni_taunt_02_wav_005a9f0c = "ni_taunt_02.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a9f1c
+char const* const s_em_taunt_02_wav_005a9f1c = "em_taunt_02.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a9f2c
+char const* const s_wa_taunt_02_wav_005a9f2c = "wa_taunt_02.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a9f3c
+char const* const s_ph_taunt_02_wav_005a9f3c = "ph_taunt_02.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a9f4c
+char const* const s_fr_taunt_02_wav_005a9f4c = "fr_taunt_02.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a9f5c
+char const* const s_ri_taunt_02_wav_005a9f5c = "ri_taunt_02.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a9f6c
+char const* const s_su_taunt_02_wav_005a9f6c = "su_taunt_02.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a9f7c
+char const* const s_ca_taunt_02_wav_005a9f7c = "ca_taunt_02.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a9f8c
+char const* const s_sa_taunt_02_wav_005a9f8c = "sa_taunt_02.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a9f9c
+char const* const s_wf_taunt_02_wav_005a9f9c = "wf_taunt_02.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a9fac
+char const* const s_pg_taunt_04_wav_005a9fac = "pg_taunt_04.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a9fbc
+char const* const s_sn_taunt_04_wav_005a9fbc = "sn_taunt_04.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a9fcc
+char const* const s_rt_taunt_02_wav_005a9fcc = "rt_taunt_02.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a9fdc
+char const* const s_all_taunt_02_wav_005a9fdc = "all_taunt_02.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005a9ff0
+char const* const s_ab_taunt_01_wav_005a9ff0 = "ab_taunt_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005aa000
+char const* const s_ma_taunt_01_wav_005aa000 = "ma_taunt_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005aa010
+char const* const s_sh_taunt_01_wav_005aa010 = "sh_taunt_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005aa020
+char const* const s_ni_taunt_01_wav_005aa020 = "ni_taunt_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005aa030
+char const* const s_em_taunt_01_wav_005aa030 = "em_taunt_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005aa040
+char const* const s_wa_taunt_01_wav_005aa040 = "wa_taunt_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005aa050
+char const* const s_ph_taunt_01_wav_005aa050 = "ph_taunt_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005aa060
+char const* const s_fr_taunt_01_wav_005aa060 = "fr_taunt_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005aa070
+char const* const s_ri_taunt_01_wav_005aa070 = "ri_taunt_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005aa080
+char const* const s_su_taunt_01_wav_005aa080 = "su_taunt_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005aa090
+char const* const s_ca_taunt_01_wav_005aa090 = "ca_taunt_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005aa0a0
+char const* const s_sa_taunt_01_wav_005aa0a0 = "sa_taunt_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005aa0b0
+char const* const s_wf_taunt_01_wav_005aa0b0 = "wf_taunt_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005aa0c0
+char const* const s_pg_taunt_03_wav_005aa0c0 = "pg_taunt_03.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005aa0d0
+char const* const s_sn_taunt_01_wav_005aa0d0 = "sn_taunt_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005aa0e0
+char const* const s_rt_taunt_01_wav_005aa0e0 = "rt_taunt_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005aa0f0
+char const* const s_all_taunt_01_wav_005aa0f0 = "all_taunt_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005aa104
+char const* const s_general_message38_wav_005aa104 = "general_message38.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005aa11c
+char const* const s_general_message37_wav_005aa11c = "general_message37.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005aa134
+char const* const s_general_message36_wav_005aa134 = "general_message36.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005aa14c
+char const* const s_general_message35_wav_005aa14c = "general_message35.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005aa164
+char const* const s_general_message34_wav_005aa164 = "general_message34.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005aa17c
+char const* const s_general_message33_wav_005aa17c = "general_message33.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005aa194
+char const* const s_general_message32_wav_005aa194 = "general_message32.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005aa1ac
+char const* const s_general_message31_wav_005aa1ac = "general_message31.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005aa1c4
+char const* const s_general_message30_wav_005aa1c4 = "general_message30.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005aa1dc
+char const* const s_general_message29_wav_005aa1dc = "general_message29.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005aa1f4
+char const* const s_general_message28_wav_005aa1f4 = "general_message28.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005aa20c
+char const* const s_general_message27_wav_005aa20c = "general_message27.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005aa224
+char const* const s_general_message26_wav_005aa224 = "general_message26.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005aa23c
+char const* const s_general_message25_wav_005aa23c = "general_message25.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005aa254
+char const* const s_general_message24_wav_005aa254 = "general_message24.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005aa26c
+char const* const s_general_message23_wav_005aa26c = "general_message23.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005aa284
+char const* const s_null_wav_005aa284 = "null.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005aa290
+char const* const s_general_message1_wav_005aa290 = "general_message1.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005aa2a8
+char const* const s_general_message8_wav_005aa2a8 = "general_message8.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005aa2c0
+char const* const s_general_message3_wav_005aa2c0 = "general_message3.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005aa2d8
+char const* const s_general_message7_wav_005aa2d8 = "general_message7.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005aa2f0
+char const* const s_general_message6_wav_005aa2f0 = "general_message6.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005aa308
+char const* const s_general_message5_wav_005aa308 = "general_message5.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005aa320
+char const* const s_general_message4_wav_005aa320 = "general_message4.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005aa338
+char const* const s_enemy_attack_24_wav_005aa338 = "enemy_attack_24.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005aa34c
+char const* const s_enemy_attack_23_wav_005aa34c = "enemy_attack_23.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005aa360
+char const* const s_enemy_attack22_wav_005aa360 = "enemy_attack22.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005aa374
+char const* const s_enemy_attack21_wav_005aa374 = "enemy_attack21.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005aa388
+char const* const s_enemy_attack20_wav_005aa388 = "enemy_attack20.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005aa39c
+char const* const s_enemy_attack19_wav_005aa39c = "enemy_attack19.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005aa3b0
+char const* const s_enemy_attack18_wav_005aa3b0 = "enemy_attack18.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005aa3c4
+char const* const s_enemy_attack17_wav_005aa3c4 = "enemy_attack17.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005aa3d8
+char const* const s_ap_narra_005aa3d8 = "ap_narra";
+
+// STRING: STRONGHOLDCRUSADER 0x005aa3e4
+char const* const s_ap_milit_005aa3e4 = "ap_milit";
+
+// STRING: STRONGHOLDCRUSADER 0x005aa3f0
+char const* const s_ap_civil_005aa3f0 = "ap_civil";
+
+// STRING: STRONGHOLDCRUSADER 0x005aa3fc
+char const* const s_ap_event_005aa3fc = "ap_event";
+
+// STRING: STRONGHOLDCRUSADER 0x005aa408
+char const* const s_wf_vict_005aa408 = "wf_vict";
+
+// STRING: STRONGHOLDCRUSADER 0x005aa410
+char const* const s_wf_plead_005aa410 = "wf_plead";
+
+// STRING: STRONGHOLDCRUSADER 0x005aa41c
+char const* const s_wf_anger_005aa41c = "wf_anger";
+
+// STRING: STRONGHOLDCRUSADER 0x005aa428
+char const* const s_wf_taunt_005aa428 = "wf_taunt";
+
+// STRING: STRONGHOLDCRUSADER 0x005aa434
+char const* const s_pg_vict_005aa434 = "pg_vict";
+
+// STRING: STRONGHOLDCRUSADER 0x005aa43c
+char const* const s_pg_plead_005aa43c = "pg_plead";
+
+// STRING: STRONGHOLDCRUSADER 0x005aa448
+char const* const s_pg_anger_005aa448 = "pg_anger";
+
+// STRING: STRONGHOLDCRUSADER 0x005aa454
+char const* const s_pg_taunt_005aa454 = "pg_taunt";
+
+// STRING: STRONGHOLDCRUSADER 0x005aa460
+char const* const s_sn_vict_005aa460 = "sn_vict";
+
+// STRING: STRONGHOLDCRUSADER 0x005aa468
+char const* const s_sn_plead_005aa468 = "sn_plead";
+
+// STRING: STRONGHOLDCRUSADER 0x005aa474
+char const* const s_sn_anger_005aa474 = "sn_anger";
+
+// STRING: STRONGHOLDCRUSADER 0x005aa480
+char const* const s_sn_taunt_005aa480 = "sn_taunt";
+
+// STRING: STRONGHOLDCRUSADER 0x005aa48c
+char const* const s_rt_vict_005aa48c = "rt_vict";
+
+// STRING: STRONGHOLDCRUSADER 0x005aa494
+char const* const s_rt_plead_005aa494 = "rt_plead";
+
+// STRING: STRONGHOLDCRUSADER 0x005aa4a0
+char const* const s_rt_anger_005aa4a0 = "rt_anger";
+
+// STRING: STRONGHOLDCRUSADER 0x005aa4ac
+char const* const s_rt_taunt_005aa4ac = "rt_taunt";
+
+// STRING: STRONGHOLDCRUSADER 0x005aa4b8
+char const* const s_adviser_005aa4b8 = "adviser";
+
+// STRING: STRONGHOLDCRUSADER 0x005aa4c0
+char const* const s_briefing_005aa4c0 = "briefing";
+
+// STRING: STRONGHOLDCRUSADER 0x005aa4cc
+char const* const s_titles_005aa4cc = "titles";
+
+// STRING: STRONGHOLDCRUSADER 0x005aa4d4
+char const* const s_tutor_005aa4d4 = "tutor";
+
+// STRING: STRONGHOLDCRUSADER 0x005aa4dc
+char const* const s_action_fire_bik_005aa4dc = "action_fire.bik";
+
+// STRING: STRONGHOLDCRUSADER 0x005aa4ec
+char const* const s_action_steal_bread_bik_005aa4ec = "action_steal_bread.bik";
+
+// STRING: STRONGHOLDCRUSADER 0x005aa504
+char const* const s_action_jester_bik_005aa504 = "action_jester.bik";
+
+// STRING: STRONGHOLDCRUSADER 0x005aa518
+char const* const s_action_marriage_bik_005aa518 = "action_marriage.bik";
+
+// STRING: STRONGHOLDCRUSADER 0x005aa52c
+char const* const s_action_archers_bik_005aa52c = "action_archers.bik";
+
+// STRING: STRONGHOLDCRUSADER 0x005aa540
+char const* const s_action_mad_cows_bik_005aa540 = "action_mad_cows.bik";
+
+// STRING: STRONGHOLDCRUSADER 0x005aa554
+char const* const s_action_bandits_bik_005aa554 = "action_bandits.bik";
+
+// STRING: STRONGHOLDCRUSADER 0x005aa568
+char const* const s_action_wolves_bik_005aa568 = "action_wolves.bik";
+
+// STRING: STRONGHOLDCRUSADER 0x005aa57c
+char const* const s_action_rabbits_bik_005aa57c = "action_rabbits.bik";
+
+// STRING: STRONGHOLDCRUSADER 0x005aa590
+char const* const s_action_trees_die_bik_005aa590 = "action_trees_die.bik";
+
+// STRING: STRONGHOLDCRUSADER 0x005aa5a8
+char const* const s_action_apples_die_bik_005aa5a8 = "action_apples_die.bik";
+
+// STRING: STRONGHOLDCRUSADER 0x005aa5c0
+char const* const s_action_hops_die_bik_005aa5c0 = "action_hops_die.bik";
+
+// STRING: STRONGHOLDCRUSADER 0x005aa5d4
+char const* const s_action_wheat_die_bik_005aa5d4 = "action_wheat_die.bik";
+
+// STRING: STRONGHOLDCRUSADER 0x005aa5ec
+char const* const s_action_plague_bik_005aa5ec = "action_plague.bik";
+
+// STRING: STRONGHOLDCRUSADER 0x005aa600
+char const* const s_action_fair_bik_005aa600 = "action_fair.bik";
+
+// STRING: STRONGHOLDCRUSADER 0x005aa610
+char const* const s_crusaders_mission4e_map_005aa610 = "crusaders_mission4e.map";
+
+// STRING: STRONGHOLDCRUSADER 0x005aa628
+char const* const s_crusaders_mission4d_map_005aa628 = "crusaders_mission4d.map";
+
+// STRING: STRONGHOLDCRUSADER 0x005aa640
+char const* const s_crusaders_mission4c_map_005aa640 = "crusaders_mission4c.map";
+
+// STRING: STRONGHOLDCRUSADER 0x005aa658
+char const* const s_crusaders_mission4b_map_005aa658 = "crusaders_mission4b.map";
+
+// STRING: STRONGHOLDCRUSADER 0x005aa670
+char const* const s_crusaders_mission4a_map_005aa670 = "crusaders_mission4a.map";
+
+// STRING: STRONGHOLDCRUSADER 0x005aa688
+char const* const s_crusaders_mission3e_map_005aa688 = "crusaders_mission3e.map";
+
+// STRING: STRONGHOLDCRUSADER 0x005aa6a0
+char const* const s_crusaders_mission3d_map_005aa6a0 = "crusaders_mission3d.map";
+
+// STRING: STRONGHOLDCRUSADER 0x005aa6b8
+char const* const s_crusaders_mission3c_map_005aa6b8 = "crusaders_mission3c.map";
+
+// STRING: STRONGHOLDCRUSADER 0x005aa6d0
+char const* const s_crusaders_mission3b_map_005aa6d0 = "crusaders_mission3b.map";
+
+// STRING: STRONGHOLDCRUSADER 0x005aa6e8
+char const* const s_crusaders_mission3a_map_005aa6e8 = "crusaders_mission3a.map";
+
+// STRING: STRONGHOLDCRUSADER 0x005aa700
+char const* const s_crusaders_mission2e_map_005aa700 = "crusaders_mission2e.map";
+
+// STRING: STRONGHOLDCRUSADER 0x005aa718
+char const* const s_crusaders_mission2d_map_005aa718 = "crusaders_mission2d.map";
+
+// STRING: STRONGHOLDCRUSADER 0x005aa730
+char const* const s_crusaders_mission2c_map_005aa730 = "crusaders_mission2c.map";
+
+// STRING: STRONGHOLDCRUSADER 0x005aa748
+char const* const s_crusaders_mission2b_map_005aa748 = "crusaders_mission2b.map";
+
+// STRING: STRONGHOLDCRUSADER 0x005aa760
+char const* const s_crusaders_mission2a_map_005aa760 = "crusaders_mission2a.map";
+
+// STRING: STRONGHOLDCRUSADER 0x005aa778
+char const* const s_crusaders_mission1e_map_005aa778 = "crusaders_mission1e.map";
+
+// STRING: STRONGHOLDCRUSADER 0x005aa790
+char const* const s_crusaders_mission1d_map_005aa790 = "crusaders_mission1d.map";
+
+// STRING: STRONGHOLDCRUSADER 0x005aa7a8
+char const* const s_crusaders_mission1c_map_005aa7a8 = "crusaders_mission1c.map";
+
+// STRING: STRONGHOLDCRUSADER 0x005aa7c0
+char const* const s_crusaders_mission1b_map_005aa7c0 = "crusaders_mission1b.map";
+
+// STRING: STRONGHOLDCRUSADER 0x005aa7d8
+char const* const s_crusaders_mission1a_map_005aa7d8 = "crusaders_mission1a.map";
+
+// STRING: STRONGHOLDCRUSADER 0x005aa7f0
+char const* const s__d_005aa7f0 = "%d";
+
+// STRING: STRONGHOLDCRUSADER 0x005aa7f4
+char const* const s__x_005aa7f4 = "(x";
+
+// STRING: STRONGHOLDCRUSADER 0x005aa7f8
+char const* const s_x_005aa7f8 = "x";
+
+// STRING: STRONGHOLDCRUSADER 0x005aa7fc
+char const* const s___005aa7fc = "!";
+
+// STRING: STRONGHOLDCRUSADER 0x005aa800
+char const* const s__s_s_005aa800 = "%s%s";
+
+// STRING: STRONGHOLDCRUSADER 0x005aa808
+char const* const s_infidel_attack_wav_005aa808 = "infidel_attack.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005aa81c
+char const* const s_good_soldier_nervous_bik_005aa81c = "good_soldier_nervous.bik";
+
+// STRING: STRONGHOLDCRUSADER 0x005aa838
+char const* const s_arabian_attack_wav_005aa838 = "arabian_attack.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005aa84c
+char const* const s_Random_Events11_wav_005aa84c = "Random_Events11.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005aa860
+char const* const s_Random_Events9_wav_005aa860 = "Random_Events9.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005aa874
+char const* const s_Random_Events8_wav_005aa874 = "Random_Events8.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005aa888
+char const* const s_Random_Events2_wav_005aa888 = "Random_Events2.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005aa89c
+char const* const s_Random_Events13_wav_005aa89c = "Random_Events13.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005aa8b0
+char const* const s_Random_Events12_wav_005aa8b0 = "Random_Events12.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005aa8c4
+char const* const s_Random_Events6_wav_005aa8c4 = "Random_Events6.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005aa8d8
+char const* const s_Random_Events7_wav_005aa8d8 = "Random_Events7.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005aa8ec
+char const* const s_Random_Events1_wav_005aa8ec = "Random_Events1.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005aa900
+char const* const s_Ap_Milit42_wav_005aa900 = "Ap_Milit42.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005aa910
+char const* const s_Ap_Milit41_wav_005aa910 = "Ap_Milit41.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005aa920
+char const* const s_Ap_Milit40_wav_005aa920 = "Ap_Milit40.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005aa930
+char const* const s_Ap_Milit39_wav_005aa930 = "Ap_Milit39.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005aa940
+char const* const s_Ap_Milit38_wav_005aa940 = "Ap_Milit38.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005aa950
+char const* const s_Ap_Milit37_wav_005aa950 = "Ap_Milit37.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005aa960
+char const* const s_Ap_Milit36_wav_005aa960 = "Ap_Milit36.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005aa970
+char const* const s_Ap_Milit35_wav_005aa970 = "Ap_Milit35.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005aa980
+char const* const s_Ap_Milit34_wav_005aa980 = "Ap_Milit34.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005aa990
+char const* const s_Ap_Milit33_wav_005aa990 = "Ap_Milit33.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005aa9a0
+char const* const s_Ap_Milit32_wav_005aa9a0 = "Ap_Milit32.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005aa9b0
+char const* const s_Ap_Milit30_wav_005aa9b0 = "Ap_Milit30.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005aa9c0
+char const* const s_Ap_Milit29_wav_005aa9c0 = "Ap_Milit29.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005aa9d0
+char const* const s_Ap_Milit28_wav_005aa9d0 = "Ap_Milit28.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005aa9e0
+char const* const s_Ap_Milit27_wav_005aa9e0 = "Ap_Milit27.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005aa9f0
+char const* const s_Ap_Milit26_wav_005aa9f0 = "Ap_Milit26.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005aaa00
+char const* const s_Ap_Milit25_wav_005aaa00 = "Ap_Milit25.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005aaa10
+char const* const s_good_soldier_taunt_bik_005aaa10 = "good_soldier_taunt.bik";
+
+// STRING: STRONGHOLDCRUSADER 0x005aaa28
+char const* const s_Ap_Milit24_wav_005aaa28 = "Ap_Milit24.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005aaa38
+char const* const s_Ap_Milit23_wav_005aaa38 = "Ap_Milit23.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005aaa48
+char const* const s_Ap_Milit22_wav_005aaa48 = "Ap_Milit22.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005aaa58
+char const* const s_Ap_Milit21_wav_005aaa58 = "Ap_Milit21.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005aaa68
+char const* const s_good_arab_nervous_bik_005aaa68 = "good_arab_nervous.bik";
+
+// STRING: STRONGHOLDCRUSADER 0x005aaa80
+char const* const s_general_warning16_wav_005aaa80 = "general_warning16.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005aaa98
+char const* const s_Random_Events10_wav_005aaa98 = "Random_Events10.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005aaaac
+char const* const s_Random_Events5_wav_005aaaac = "Random_Events5.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005aaac0
+char const* const s_Random_Events4_wav_005aaac0 = "Random_Events4.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005aaad4
+char const* const s_Random_Events3_wav_005aaad4 = "Random_Events3.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005aaae8
+char const* const s_ap_civil12_bik_005aaae8 = "ap_civil12.bik";
+
+// STRING: STRONGHOLDCRUSADER 0x005aac60
+char const* const s_SK_ABBOT_005aac60 = "SK_ABBOT";
+
+// STRING: STRONGHOLDCRUSADER 0x005aac6c
+char const* const s_SK_MARSHAL_005aac6c = "SK_MARSHAL";
+
+// STRING: STRONGHOLDCRUSADER 0x005aac78
+char const* const s_SK_SHERIFF_005aac78 = "SK_SHERIFF";
+
+// STRING: STRONGHOLDCRUSADER 0x005aac84
+char const* const s_SK_NIZAR_005aac84 = "SK_NIZAR";
+
+// STRING: STRONGHOLDCRUSADER 0x005aac90
+char const* const s_SK_EMIR_005aac90 = "SK_EMIR";
+
+// STRING: STRONGHOLDCRUSADER 0x005aac98
+char const* const s_SK_WAZIR_005aac98 = "SK_WAZIR";
+
+// STRING: STRONGHOLDCRUSADER 0x005aaca4
+char const* const s_SK_PHILLIP_005aaca4 = "SK_PHILLIP";
+
+// STRING: STRONGHOLDCRUSADER 0x005aacb0
+char const* const s_SK_FREDERICK_005aacb0 = "SK_FREDERICK";
+
+// STRING: STRONGHOLDCRUSADER 0x005aacc0
+char const* const s_SK_RICHARD_005aacc0 = "SK_RICHARD";
+
+// STRING: STRONGHOLDCRUSADER 0x005aaccc
+char const* const s_SK_SULTAN_005aaccc = "SK_SULTAN";
+
+// STRING: STRONGHOLDCRUSADER 0x005aacd8
+char const* const s_SK_CALIPH_005aacd8 = "SK_CALIPH";
+
+// STRING: STRONGHOLDCRUSADER 0x005aace4
+char const* const s_SK_SALADIN_005aace4 = "SK_SALADIN";
+
+// STRING: STRONGHOLDCRUSADER 0x005aacf0
+char const* const s_SK_WOLF_005aacf0 = "SK_WOLF";
+
+// STRING: STRONGHOLDCRUSADER 0x005aacf8
+char const* const s_SK_PIG_005aacf8 = "SK_PIG";
+
+// STRING: STRONGHOLDCRUSADER 0x005aad00
+char const* const s_SK_SNAKE_005aad00 = "SK_SNAKE";
+
+// STRING: STRONGHOLDCRUSADER 0x005aad0c
+char const* const s_SK_RAT_005aad0c = "SK_RAT";
+
+// STRING: STRONGHOLDCRUSADER 0x005aad14
+char const* const s_SK_NULL_005aad14 = "SK_NULL";
+
+// STRING: STRONGHOLDCRUSADER 0x005aad1c
+char const* const s_Df_d_d_005aad1c = "Df:%d/%d";
+
+// STRING: STRONGHOLDCRUSADER 0x005aad28
+char const* const s_Hr_d_d_005aad28 = "Hr:%d/%d";
+
+// STRING: STRONGHOLDCRUSADER 0x005aad34
+char const* const s_Sg_d_d_005aad34 = "Sg:%d/%d";
+
+// STRING: STRONGHOLDCRUSADER 0x005aad40
+char const* const s_E_d_d_005aad40 = "E:%d/%d";
+
+// STRING: STRONGHOLDCRUSADER 0x005aad48
+char const* const s_AIV___d_005aad48 = "AIV: %d";
+
+// STRING: STRONGHOLDCRUSADER 0x005aad50
+char const* const s_AIV_n_a_005aad50 = "AIV:n/a";
+
+// STRING: STRONGHOLDCRUSADER 0x005aad58
+char const* const s_Atk_d_W_d_005aad58 = "Atk:%d W:%d";
+
+// STRING: STRONGHOLDCRUSADER 0x005aad64
+char const* const s_P__005aad64 = "P:";
+
+// STRING: STRONGHOLDCRUSADER 0x005aad68
+char const* const s_Strong_005aad68 = "Strong";
+
+// STRING: STRONGHOLDCRUSADER 0x005aad70
+char const* const s_Normal_005aad70 = "Normal";
+
+// STRING: STRONGHOLDCRUSADER 0x005aad78
+char const* const s_Weak_005aad78 = "Weak";
+
+// STRING: STRONGHOLDCRUSADER 0x005aad80
+char const* const s_skmasters2_dat_005aad80 = "skmasters2.dat";
+
+// STRING: STRONGHOLDCRUSADER 0x005aada4
+char const* const s_defeat_stocks_tgx_005aada4 = "defeat_stocks.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005aadb8
+char const* const s_defeat_snake_tgx_005aadb8 = "defeat_snake.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005aadcc
+char const* const s_defeat_ruins_tgx_005aadcc = "defeat_ruins.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005aade0
+char const* const s_defeat_rat_tgx_005aade0 = "defeat_rat.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005aadf0
+char const* const s_defeat_pig_tgx_005aadf0 = "defeat_pig.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005aae00
+char const* const s_defeat_general_tgx_005aae00 = "defeat_general.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005aae14
+char const* const s_defeat_baddies_tgx_005aae14 = "defeat_baddies.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005aae28
+char const* const s_victory_stockpile_tgx_005aae28 = "victory_stockpile.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005aae40
+char const* const s_victory_snake_tgx_005aae40 = "victory_snake.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005aae54
+char const* const s_victory_resources_tgx_005aae54 = "victory_resources.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005aae6c
+char const* const s_victory_rat_tgx_005aae6c = "victory_rat.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005aae7c
+char const* const s_victory_pig_tgx_005aae7c = "victory_pig.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005aae8c
+char const* const s_victory_military_small_tgx_005aae8c = "victory_military_small.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005aaea8
+char const* const s_victory_military_big_tgx_005aaea8 = "victory_military_big.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005aaec4
+char const* const s_victory_economic_tgx_005aaec4 = "victory_economic.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005aaedc
+char const* const s_victory_banquet_tgx_005aaedc = "victory_banquet.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005aaef0
+char const* const s_crusader_lose_bik_005aaef0 = "crusader_lose.bik";
+
+// STRING: STRONGHOLDCRUSADER 0x005aaf04
+char const* const s_arabian_lose_bik_005aaf04 = "arabian_lose.bik";
+
+// STRING: STRONGHOLDCRUSADER 0x005aaf18
+char const* const s____M_d_d_sav_005aaf18 = " :   -M%d-%d.sav";
+
+// STRING: STRONGHOLDCRUSADER 0x005aaf2c
+char const* const s____d_005aaf2c = " : %d        ";
+
+// STRING: STRONGHOLDCRUSADER 0x005aaf3c
+char const* const s__s__d____s__d_005aaf3c = "%s %d - %s %d";
+
+// STRING: STRONGHOLDCRUSADER 0x005aaf4c
+char const* const s_gfx8_campaign_map_england_hotspo_005aaf4c = "gfx8\\campaign_map_england_hotspots.bmp";
+
+// STRING: STRONGHOLDCRUSADER 0x005aaf74
+char const* const s___005aaf74 = " (";
+
+// STRING: STRONGHOLDCRUSADER 0x005aaf78
+char const* const s___005aaf78 = " ()";
+
+// STRING: STRONGHOLDCRUSADER 0x005aaf7c
+char const* const s_mission_d_hlp_005aaf7c = "mission%d.hlp";
+
+// STRING: STRONGHOLDCRUSADER 0x005aaf8c
+char const* const s_skirmish_background_tgx_005aaf8c = "skirmish_background.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005aafa4
+char const* const s_skirmish_trail_tgx_005aafa4 = "skirmish_trail.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005aafb8
+char const* const s_skirmish_trail2_tgx_005aafb8 = "skirmish_trail2.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005aafcc
+char const* const s_shcx_map_tgx_005aafcc = "shcx_map.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005aafdc
+char const* const s_lose_screen_arab_tgx_005aafdc = "lose_screen_arab.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005aaff4
+char const* const s_lose_screen_crusader_tgx_005aaff4 = "lose_screen_crusader.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005ab010
+char const* const s_win_screen_arab_tgx_005ab010 = "win_screen_arab.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005ab024
+char const* const s_win_screen_crusader_tgx_005ab024 = "win_screen_crusader.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005ab040
+char const* const s_pc7_tgx_005ab040 = "pc7.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005ab048
+char const* const s_pc6_tgx_005ab048 = "pc6.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005ab050
+char const* const s_pc5_tgx_005ab050 = "pc5.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005ab058
+char const* const s_pc4_tgx_005ab058 = "pc4.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005ab060
+char const* const s_pc3_tgx_005ab060 = "pc3.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005ab068
+char const* const s_pc2_tgx_005ab068 = "pc2.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005ab070
+char const* const s_pc1_tgx_005ab070 = "pc1.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005ab078
+char const* const s_pc0_tgx_005ab078 = "pc0.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005ab080
+char const* const s_sand_tgx_005ab080 = "sand.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005ab0a0
+char const* const s_m_dpic_tgx_005ab0a0 = "m%dpic.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005ab0b8
+char const* const s_m_dmap_tgx_005ab0b8 = "m%dmap.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005ab0c8
+char const* const s_c4pic_tgx_005ab0c8 = "c4pic.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005ab0d4
+char const* const s_c3pic_tgx_005ab0d4 = "c3pic.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005ab0e0
+char const* const s_c2pic_tgx_005ab0e0 = "c2pic.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005ab0ec
+char const* const s_c1pic_tgx_005ab0ec = "c1pic.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005ab114
+char const* const s_fx_speech_intro_03_wav_005ab114 = "fx\\speech\\intro_03.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005ab12c
+char const* const s_fx_speech_intro_02_wav_005ab12c = "fx\\speech\\intro_02.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005ab144
+char const* const s_fx_speech_intro_01_wav_005ab144 = "fx\\speech\\intro_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005ab15c
+char const* const s_fx_speech_after_04_wav_005ab15c = "fx\\speech\\after_04.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005ab174
+char const* const s_fx_speech_after_03_wav_005ab174 = "fx\\speech\\after_03.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005ab18c
+char const* const s_fx_speech_after_02_wav_005ab18c = "fx\\speech\\after_02.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005ab1a4
+char const* const s_fx_speech_after_01_wav_005ab1a4 = "fx\\speech\\after_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005ab1bc
+char const* const s_p2_tgx_005ab1bc = "p2.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005ab1c4
+char const* const s_p1_tgx_005ab1c4 = "p1.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005ab1cc
+char const* const s_p3_tgx_005ab1cc = "p3.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005ab1d4
+char const* const s_p4_tgx_005ab1d4 = "p4.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005ab1dc
+char const* const s_logo_280x100_tgx_005ab1dc = "logo_280x100.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005ab1f0
+char const* const s_demo4_tgx_005ab1f0 = "demo4.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005ab1fc
+char const* const s_demo3_tgx_005ab1fc = "demo3.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005ab208
+char const* const s_demo2_tgx_005ab208 = "demo2.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005ab214
+char const* const s_demo1_tgx_005ab214 = "demo1.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005ab220
+char const* const s_bullet2_tgx_005ab220 = "bullet2.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005ab22c
+char const* const s_map_wolf_tgx_005ab22c = "map_wolf.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005ab23c
+char const* const s_map_snake_tgx_005ab23c = "map_snake.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005ab24c
+char const* const s_map_rat_tgx_005ab24c = "map_rat.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005ab258
+char const* const s_map_pig_tgx_005ab258 = "map_pig.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005ab264
+char const* const s_campaign_map_england_20_tgx_005ab264 = "campaign_map_england_20.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005ab280
+char const* const s_campaign_map_england_19_tgx_005ab280 = "campaign_map_england_19.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005ab29c
+char const* const s_campaign_map_england_18_tgx_005ab29c = "campaign_map_england_18.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005ab2b8
+char const* const s_campaign_map_england_17_tgx_005ab2b8 = "campaign_map_england_17.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005ab2d4
+char const* const s_campaign_map_england_16_tgx_005ab2d4 = "campaign_map_england_16.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005ab2f0
+char const* const s_campaign_map_england_15_tgx_005ab2f0 = "campaign_map_england_15.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005ab30c
+char const* const s_campaign_map_england_14_tgx_005ab30c = "campaign_map_england_14.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005ab328
+char const* const s_campaign_map_england_13_tgx_005ab328 = "campaign_map_england_13.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005ab344
+char const* const s_campaign_map_england_12_tgx_005ab344 = "campaign_map_england_12.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005ab360
+char const* const s_campaign_map_england_11_tgx_005ab360 = "campaign_map_england_11.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005ab37c
+char const* const s_campaign_map_england_10_tgx_005ab37c = "campaign_map_england_10.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005ab398
+char const* const s_campaign_map_england_09_tgx_005ab398 = "campaign_map_england_09.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005ab3b4
+char const* const s_campaign_map_england_08_tgx_005ab3b4 = "campaign_map_england_08.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005ab3d0
+char const* const s_campaign_map_england_07_tgx_005ab3d0 = "campaign_map_england_07.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005ab3ec
+char const* const s_campaign_map_england_06_tgx_005ab3ec = "campaign_map_england_06.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005ab408
+char const* const s_campaign_map_england_05_tgx_005ab408 = "campaign_map_england_05.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005ab424
+char const* const s_campaign_map_england_04_tgx_005ab424 = "campaign_map_england_04.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005ab440
+char const* const s_campaign_map_england_03_tgx_005ab440 = "campaign_map_england_03.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005ab45c
+char const* const s_campaign_map_england_02_tgx_005ab45c = "campaign_map_england_02.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005ab478
+char const* const s_campaign_map_england_01_tgx_005ab478 = "campaign_map_england_01.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005ab494
+char const* const s_campaign_map_england_tgx_005ab494 = "campaign_map_england.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005ab4b0
+char const* const s_briefing_back12_tgx_005ab4b0 = "briefing_back12.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005ab4c4
+char const* const s_briefing_back11_tgx_005ab4c4 = "briefing_back11.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005ab4d8
+char const* const s_briefing_back10_tgx_005ab4d8 = "briefing_back10.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005ab4ec
+char const* const s_briefing_back9_tgx_005ab4ec = "briefing_back9.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005ab500
+char const* const s_briefing_back8_tgx_005ab500 = "briefing_back8.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005ab514
+char const* const s_briefing_back7_tgx_005ab514 = "briefing_back7.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005ab528
+char const* const s_briefing_back6_tgx_005ab528 = "briefing_back6.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005ab53c
+char const* const s_briefing_back5_tgx_005ab53c = "briefing_back5.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005ab550
+char const* const s_briefing_back4_tgx_005ab550 = "briefing_back4.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005ab564
+char const* const s_briefing_back3_tgx_005ab564 = "briefing_back3.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005ab578
+char const* const s_briefing_back2_tgx_005ab578 = "briefing_back2.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005ab58c
+char const* const s_briefing_back1_tgx_005ab58c = "briefing_back1.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005ab5a0
+char const* const s_briefing_back0_tgx_005ab5a0 = "briefing_back0.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005ab5b4
+char const* const s_briefing_screen_background_tgx_005ab5b4 = "briefing_screen_background.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005ab5d4
+char const* const s___005ab5d4 = ".";
+
+// STRING: STRONGHOLDCRUSADER 0x005ab5d8
+char const* const s_n__Chr__005ab5d8 = " n. Chr.";
+
+// STRING: STRONGHOLDCRUSADER 0x005ab5e4
+char const* const s_A_D__005ab5e4 = " A.D.";
+
+// STRING: STRONGHOLDCRUSADER 0x005ab5ec
+char const* const s_fx_speech_ca_add_player_01_wav_005ab5ec = "fx\\speech\\ca_add_player_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005ab60c
+char const* const s_fx_speech_ri_congrats_01_wav_005ab60c = "fx\\speech\\ri_congrats_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005ab62c
+char const* const s_fx_speech_su_congrats_01_wav_005ab62c = "fx\\speech\\su_congrats_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005ab64c
+char const* const s_fx_speech_sa_extra_01_wav_005ab64c = "fx\\speech\\sa_extra_01.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005ab668
+char const* const s_fx_speech_wf_anger_04_wav_005ab668 = "fx\\speech\\wf_anger_04.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005ab684
+char const* const s_fx_speech_pg_add_player_wav_005ab684 = "fx\\speech\\pg_add_player.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005ab6a0
+char const* const s_fx_speech_sn_add_player_wav_005ab6a0 = "fx\\speech\\sn_add_player.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005ab6bc
+char const* const s_fx_speech_rt_anger_04_wav_005ab6bc = "fx\\speech\\rt_anger_04.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005ab6d8
+char const* const s_jesterlast_tgx_005ab6d8 = "jesterlast.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005ab6e8
+char const* const s_endframe8_tgx_005ab6e8 = "endframe8.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005ab6f8
+char const* const s_endframe7_tgx_005ab6f8 = "endframe7.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005ab708
+char const* const s_endframe6_tgx_005ab708 = "endframe6.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005ab718
+char const* const s_endframe5_tgx_005ab718 = "endframe5.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005ab728
+char const* const s_endframe4_tgx_005ab728 = "endframe4.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005ab738
+char const* const s_endframe3_tgx_005ab738 = "endframe3.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005ab748
+char const* const s_endframe2_tgx_005ab748 = "endframe2.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005ab758
+char const* const s_endframe1_tgx_005ab758 = "endframe1.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005ab768
+char const* const s_sktrail_win_tgx_005ab768 = "sktrail_win.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005ab778
+char const* const s_1___005ab778 = "1 / ";
+
+// STRING: STRONGHOLDCRUSADER 0x005ab780
+char const* const s_2___005ab780 = "2 / ";
+
+// STRING: STRONGHOLDCRUSADER 0x005ab788
+char const* const s_3___005ab788 = "3 / ";
+
+// STRING: STRONGHOLDCRUSADER 0x005ab790
+char const* const s__d_d_005ab790 = "%d:%d";
+
+// STRING: STRONGHOLDCRUSADER 0x005ab798
+char const* const s__d_0_d_005ab798 = "%d:0%d";
+
+// STRING: STRONGHOLDCRUSADER 0x005ab7a0
+char const* const s__s__005ab7a0 = "\"%s\"";
+
+// STRING: STRONGHOLDCRUSADER 0x005ab7a8
+char const* const s___005ab7a8 = "...";
+
+// STRING: STRONGHOLDCRUSADER 0x005ab7b8
+char const* const s_sco_005ab7b8 = "sco";
+
+// STRING: STRONGHOLDCRUSADER 0x005ab7bc
+char const* const s_general_victory2_wav_005ab7bc = "general_victory2.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005ab7d4
+char const* const s_general_victory1_wav_005ab7d4 = "general_victory1.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005ab7ec
+char const* const s_crusader_win_bik_005ab7ec = "crusader_win.bik";
+
+// STRING: STRONGHOLDCRUSADER 0x005ab800
+char const* const s_arabian_win_bik_005ab800 = "arabian_win.bik";
+
+// STRING: STRONGHOLDCRUSADER 0x005ab810
+char const* const s_Damage_Layer___d__d_005ab810 = "Damage Layer: %d  %d";
+
+// STRING: STRONGHOLDCRUSADER 0x005ab828
+char const* const s_Logic2_Layer___x__x_005ab828 = "Logic2 Layer: %x  %x";
+
+// STRING: STRONGHOLDCRUSADER 0x005ab840
+char const* const s_Logic_Layer___x__x_005ab840 = "Logic Layer: %x  %x";
+
+// STRING: STRONGHOLDCRUSADER 0x005ab854
+char const* const s_Chimp___d_Struct___d_Fly___d_005ab854 = "Chimp: %d  Struct: %d Fly: %d";
+
+// STRING: STRONGHOLDCRUSADER 0x005ab874
+char const* const s_Tile_centre__x_d_y_d_005ab874 = "Tile centre: x%d,y%d";
+
+// STRING: STRONGHOLDCRUSADER 0x005ab88c
+char const* const s_Mouse__x_d__y_d__off_d_005ab88c = "Mouse: x%d, y%d, off%d";
+
+// STRING: STRONGHOLDCRUSADER 0x005ab8a4
+char const* const s_Mouse_Atom_Ref___d_005ab8a4 = "Mouse Atom Ref: %d";
+
+// STRING: STRONGHOLDCRUSADER 0x005ab8b8
+char const* const s_Genie_35_wav_005ab8b8 = "Genie_35.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005ab8c8
+char const* const s_No_views_have_been_found__005ab8c8 = "No views have been found.";
+
+// STRING: STRONGHOLDCRUSADER 0x005ab8e4
+char const* const s_stronghold_uc_005ab8e4 = "stronghold.uc";
+
+// STRING: STRONGHOLDCRUSADER 0x005ab8f4
+char const* const s_placement_warning1_wav_005ab8f4 = "placement_warning1.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005ab90c
+char const* const s_Genie_24_wav_005ab90c = "Genie_24.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005ab91c
+char const* const s_Genie_23_wav_005ab91c = "Genie_23.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005ab92c
+char const* const s_Genie_36_wav_005ab92c = "Genie_36.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005ab93c
+char const* const s_Points___d___d___d___d___d___d____005ab93c = "Points: %d, %d, %d, %d, %d, %d, %d, %d, %d ";
+
+// STRING: STRONGHOLDCRUSADER 0x005ab968
+char const* const s_killed_d_lost_d_AI_troops_d_005ab968 = "killed:%d lost:%d AI troops:%d";
+
+// STRING: STRONGHOLDCRUSADER 0x005ab988
+char const* const s_ai_troops__A_d_X_d_S_d_P_d_M_005ab988
+    = "ai troops: A:%d X:%d S:%d P:%d M:%d S:%d K:%d L:%d E:%d T:%d";
+
+// STRING: STRONGHOLDCRUSADER 0x005ab9c8
+char const* const s_Tent_points_d__Next_d_005ab9c8 = "Tent points:%d,  Next:%d";
+
+// STRING: STRONGHOLDCRUSADER 0x005ab9e4
+char const* const s_Support_points_d__Next_d_005ab9e4 = "Support points:%d,  Next:%d";
+
+// STRING: STRONGHOLDCRUSADER 0x005aba00
+char const* const s_Archer_points_d__Next_d_005aba00 = "Archer points:%d,  Next:%d";
+
+// STRING: STRONGHOLDCRUSADER 0x005aba1c
+char const* const s_Wide_d_d_d__005aba1c = "Wide:%d(%d)(%d)";
+
+// STRING: STRONGHOLDCRUSADER 0x005aba2c
+char const* const s_High_d_d_d__Arch_d_d_d__P_005aba2c = "High:%d(%d)(%d)  Arch:%d(%d)(%d)  People:%d(%d)(%d)";
+
+// STRING: STRONGHOLDCRUSADER 0x005aba60
+char const* const s_Town_d_d__Gate_d_d__Moat_d__005aba60 = "Town:%d(%d)  Gate:%d(%d)  Moat:%d(%d) Lord:%d(%d)";
+
+// STRING: STRONGHOLDCRUSADER 0x005aba94
+char const* const s_Hack_d_d_d__Scale_d_d_d__005aba94 = "Hack:%d(%d)(%d)  Scale:%d(%d)(%d) Stone:%d";
+
+// STRING: STRONGHOLDCRUSADER 0x005abac0
+char const* const s_zone_size__005abac0 = "zone size: ";
+
+// STRING: STRONGHOLDCRUSADER 0x005abacc
+char const* const s_cas_dis__005abacc = "cas dis: ";
+
+// STRING: STRONGHOLDCRUSADER 0x005abad8
+char const* const s_Keep_con__005abad8 = "Keep con: ";
+
+// STRING: STRONGHOLDCRUSADER 0x005abae4
+char const* const s_Start_con__005abae4 = "Start con: ";
+
+// STRING: STRONGHOLDCRUSADER 0x005abaf0
+char const* const s_nof_tribes__005abaf0 = "nof tribes: ";
+
+// STRING: STRONGHOLDCRUSADER 0x005abb00
+char const* const s_inv_count__005abb00 = "inv count: ";
+
+// STRING: STRONGHOLDCRUSADER 0x005abb0c
+char const* const s_nof_fpoints__005abb0c = "nof fpoints: ";
+
+// STRING: STRONGHOLDCRUSADER 0x005abb1c
+char const* const s_keep_POS__005abb1c = "keep POS: ";
+
+// STRING: STRONGHOLDCRUSADER 0x005abb28
+char const* const s_Scale_zone__005abb28 = "Scale zone: ";
+
+// STRING: STRONGHOLDCRUSADER 0x005abb38
+char const* const s_Start_zone__005abb38 = "Start zone: ";
+
+// STRING: STRONGHOLDCRUSADER 0x005abb48
+char const* const s_Biggest_zone__005abb48 = "Biggest zone: ";
+
+// STRING: STRONGHOLDCRUSADER 0x005abb58
+char const* const s_drumhorn_wav_005abb58 = "drumhorn.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005abb68
+char const* const s_Mace_s4_wav_005abb68 = "Mace_s4.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005abb74
+char const* const s_Slink_005abb74 = "Slink  ";
+
+// STRING: STRONGHOLDCRUSADER 0x005abb7c
+char const* const s_Siege_005abb7c = "Siege  ";
+
+// STRING: STRONGHOLDCRUSADER 0x005abb84
+char const* const s_Panic_005abb84 = "Panic  ";
+
+// STRING: STRONGHOLDCRUSADER 0x005abb8c
+char const* const s_Route_005abb8c = "Route  ";
+
+// STRING: STRONGHOLDCRUSADER 0x005abb94
+char const* const s_Deer_005abb94 = "Deer  ";
+
+// STRING: STRONGHOLDCRUSADER 0x005abb9c
+char const* const s_Mankind_005abb9c = "Mankind  ";
+
+// STRING: STRONGHOLDCRUSADER 0x005abba8
+char const* const s_Humans_005abba8 = "Humans  ";
+
+// STRING: STRONGHOLDCRUSADER 0x005abbb4
+char const* const s_Farmland_005abbb4 = "Farmland   ";
+
+// STRING: STRONGHOLDCRUSADER 0x005abbc0
+char const* const s_Chimps_005abbc0 = "Chimps  ";
+
+// STRING: STRONGHOLDCRUSADER 0x005abbcc
+char const* const s_Connect_005abbcc = "Connect ";
+
+// STRING: STRONGHOLDCRUSADER 0x005abbd8
+char const* const s_placement_warning10_wav_005abbd8 = "placement_warning10.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005abbf0
+char const* const s_placement_warning11_wav_005abbf0 = "placement_warning11.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005abc08
+char const* const s_placement_warning12_wav_005abc08 = "placement_warning12.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005abc20
+char const* const s_SA_005abc20 = "SA ";
+
+// STRING: STRONGHOLDCRUSADER 0x005abc24
+char const* const s_Tribe_005abc24 = "Tribe ";
+
+// STRING: STRONGHOLDCRUSADER 0x005abc2c
+char const* const s_Bless_005abc2c = "Bless ";
+
+// STRING: STRONGHOLDCRUSADER 0x005abc34
+char const* const s_Av_005abc34 = "Av ";
+
+// STRING: STRONGHOLDCRUSADER 0x005abc38
+char const* const s_Working_005abc38 = "Working ";
+
+// STRING: STRONGHOLDCRUSADER 0x005abc44
+char const* const s_Banked_005abc44 = "Banked ";
+
+// STRING: STRONGHOLDCRUSADER 0x005abc4c
+char const* const s_Target_005abc4c = "Target ";
+
+// STRING: STRONGHOLDCRUSADER 0x005abc54
+char const* const s_Idle_005abc54 = "Idle ";
+
+// STRING: STRONGHOLDCRUSADER 0x005abc5c
+char const* const s_was_on_stone_gate_005abc5c = "was on stone gate ";
+
+// STRING: STRONGHOLDCRUSADER 0x005abc70
+char const* const s_vanish_005abc70 = "vanish ";
+
+// STRING: STRONGHOLDCRUSADER 0x005abc78
+char const* const s_seated_005abc78 = "seated ";
+
+// STRING: STRONGHOLDCRUSADER 0x005abc80
+char const* const s_target_type_005abc80 = "target type ";
+
+// STRING: STRONGHOLDCRUSADER 0x005abc90
+char const* const s_Hunted_By_005abc90 = "Hunted By ";
+
+// STRING: STRONGHOLDCRUSADER 0x005abc9c
+char const* const s_Hps_005abc9c = "Hps ";
+
+// STRING: STRONGHOLDCRUSADER 0x005abca4
+char const* const s_Attacked_By_005abca4 = "Attacked By ";
+
+// STRING: STRONGHOLDCRUSADER 0x005abcb4
+char const* const s_Look_4_enemy_005abcb4 = "Look 4 enemy ";
+
+// STRING: STRONGHOLDCRUSADER 0x005abcc4
+char const* const s_gfx_no_005abcc4 = "gfx_no ";
+
+// STRING: STRONGHOLDCRUSADER 0x005abccc
+char const* const s_anim_frame_no_005abccc = "anim_frame_no ";
+
+// STRING: STRONGHOLDCRUSADER 0x005abcdc
+char const* const s_ai_status_005abcdc = "ai_status ";
+
+// STRING: STRONGHOLDCRUSADER 0x005abce8
+char const* const s_z_005abce8 = "z ";
+
+// STRING: STRONGHOLDCRUSADER 0x005abcec
+char const* const s_jump_005abcec = "jump ";
+
+// STRING: STRONGHOLDCRUSADER 0x005abcf4
+char const* const s_facing_005abcf4 = "facing ";
+
+// STRING: STRONGHOLDCRUSADER 0x005abcfc
+char const* const s_enemyD_005abcfc = "enemyD ";
+
+// STRING: STRONGHOLDCRUSADER 0x005abd04
+char const* const s_sloth__005abd04 = "sloth: ";
+
+// STRING: STRONGHOLDCRUSADER 0x005abd0c
+char const* const s_elbowed__005abd0c = "elbowed: ";
+
+// STRING: STRONGHOLDCRUSADER 0x005abd18
+char const* const s_using_teleport__005abd18 = "using teleport: ";
+
+// STRING: STRONGHOLDCRUSADER 0x005abd2c
+char const* const s_next_chimp__005abd2c = "next_chimp: ";
+
+// STRING: STRONGHOLDCRUSADER 0x005abd3c
+char const* const s_dying__005abd3c = "dying: ";
+
+// STRING: STRONGHOLDCRUSADER 0x005abd44
+char const* const s_status__005abd44 = "status: ";
+
+// STRING: STRONGHOLDCRUSADER 0x005abd50
+char const* const s_player__005abd50 = "player: ";
+
+// STRING: STRONGHOLDCRUSADER 0x005abd5c
+char const* const s_type__005abd5c = "type: ";
+
+// STRING: STRONGHOLDCRUSADER 0x005abd64
+char const* const s_Watching_chimp__005abd64 = "Watching chimp: ";
+
+// STRING: STRONGHOLDCRUSADER 0x005abd78
+char const* const s_Lost_chimps__005abd78 = "Lost chimps: ";
+
+// STRING: STRONGHOLDCRUSADER 0x005abd88
+char const* const s_total_zones__005abd88 = "total zones: ";
+
+// STRING: STRONGHOLDCRUSADER 0x005abd98
+char const* const s_greatest_loading__005abd98 = "greatest loading: ";
+
+// STRING: STRONGHOLDCRUSADER 0x005abdac
+char const* const s_No_of_teleports__005abdac = "No of teleports: ";
+
+// STRING: STRONGHOLDCRUSADER 0x005abdc0
+char const* const s_Total_flies__005abdc0 = "Total flies: ";
+
+// STRING: STRONGHOLDCRUSADER 0x005abdd0
+char const* const s_Total_chimps__005abdd0 = "Total chimps: ";
+
+// STRING: STRONGHOLDCRUSADER 0x005abde0
+char const* const s_Not_watching_a_chimp_005abde0 = "Not watching a chimp ";
+
+// STRING: STRONGHOLDCRUSADER 0x005abdf8
+char const* const s_General_Warning5_wav_005abdf8 = "General_Warning5.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005abe10
+char const* const s_General_Warning6_wav_005abe10 = "General_Warning6.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005abe28
+char const* const s_General_Warning11_wav_005abe28 = "General_Warning11.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005abe40
+char const* const s_General_Warning17_wav_005abe40 = "General_Warning17.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005abe58
+char const* const s_General_Warning12_wav_005abe58 = "General_Warning12.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005abe70
+char const* const s_general_victory5_wav_005abe70 = "general_victory5.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005abe88
+char const* const s_general_victory4_wav_005abe88 = "general_victory4.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005abea0
+char const* const s_general_victory3_wav_005abea0 = "general_victory3.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005abeb8
+char const* const s_general_warning1_wav_005abeb8 = "general_warning1.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005abed0
+char const* const s__s__d__s_005abed0 = "%s %d %s";
+
+// STRING: STRONGHOLDCRUSADER 0x005abedc
+char const* const s_General_Warning18_wav_005abedc = "General_Warning18.wav";
+
+// STRING: STRONGHOLDCRUSADER 0x005abef4
+char const* const s_open_005abef4 = "open";
+
+// STRING: STRONGHOLDCRUSADER 0x005abefc
+char const* const s__svc_strongholdce_005abefc = "+svc strongholdce";
+
+// STRING: STRONGHOLDCRUSADER 0x005abf10
+char const* const s_frontend_loading_tgx_005abf10 = "frontend_loading.tgx";
+
+// STRING: STRONGHOLDCRUSADER 0x005abf28
+char const* const s_Stronghold_Crusader_is_already_r_005abf28 = "Stronghold Crusader is already running.";
+
+// STRING: STRONGHOLDCRUSADER 0x005abf50
+char const* const s_Stronghold_Crusader_Error_005abf50 = "Stronghold Crusader Error";
+
+// STRING: STRONGHOLDCRUSADER 0x005abf6c
+char const* const s_Global_FireflyStrongholdCrusader_005abf6c = "Global\\FireflyStrongholdCrusadersExtreme";
+
+// STRING: STRONGHOLDCRUSADER 0x005abf98
+char const* const s_kernel32_dll_005abf98 = "kernel32.dll";
+
+// STRING: STRONGHOLDCRUSADER 0x005abfa8
+char const* const s_WideCharToMultiByte_005abfa8 = "WideCharToMultiByte";
+
+// STRING: STRONGHOLDCRUSADER 0x005abfbc
+char const* const s_MultiByteToWideChar_005abfbc = "MultiByteToWideChar";
+
+// STRING: STRONGHOLDCRUSADER 0x005abfd0
+char const* const s_GetProcAddress_005abfd0 = "GetProcAddress";
+
+// STRING: STRONGHOLDCRUSADER 0x005abfe0
+char const* const s_user32_dll_005abfe0 = "user32.dll";
+
+// STRING: STRONGHOLDCRUSADER 0x005abfec
+char const* const s_SetWindowLongA_005abfec = "SetWindowLongA";
+
+// STRING: STRONGHOLDCRUSADER 0x005abffc
+char const* const s_GetShortPathNameW_005abffc = "GetShortPathNameW";
+
+// STRING: STRONGHOLDCRUSADER 0x005ac010
+char const* const s_msvfw32_dll_005ac010 = "msvfw32.dll";
+
+// STRING: STRONGHOLDCRUSADER 0x005ac01c
+char const* const s_sensapi_dll_005ac01c = "sensapi.dll";
+
+// STRING: STRONGHOLDCRUSADER 0x005ac028
+char const* const s_oledlg_dll_005ac028 = "oledlg.dll";
+
+// STRING: STRONGHOLDCRUSADER 0x005ac034
+char const* const s_oleacc_dll_005ac034 = "oleacc.dll";
+
+// STRING: STRONGHOLDCRUSADER 0x005ac040
+char const* const s_secur32_dll_005ac040 = "secur32.dll";
+
+// STRING: STRONGHOLDCRUSADER 0x005ac04c
+char const* const s_avicap32_dll_005ac04c = "avicap32.dll";
+
+// STRING: STRONGHOLDCRUSADER 0x005ac05c
+char const* const s_winspool_drv_005ac05c = "winspool.drv";
+
+// STRING: STRONGHOLDCRUSADER 0x005ac06c
+char const* const s_winmm_dll_005ac06c = "winmm.dll";
+
+// STRING: STRONGHOLDCRUSADER 0x005ac078
+char const* const s_rasapi32_dll_005ac078 = "rasapi32.dll";
+
+// STRING: STRONGHOLDCRUSADER 0x005ac088
+char const* const s_mpr_dll_005ac088 = "mpr.dll";
+
+// STRING: STRONGHOLDCRUSADER 0x005ac090
+char const* const s_version_dll_005ac090 = "version.dll";
+
+// STRING: STRONGHOLDCRUSADER 0x005ac09c
+char const* const s_comdlg32_dll_005ac09c = "comdlg32.dll";
+
+// STRING: STRONGHOLDCRUSADER 0x005ac0ac
+char const* const s_shell32_dll_005ac0ac = "shell32.dll";
+
+// STRING: STRONGHOLDCRUSADER 0x005ac0b8
+char const* const s_advapi32_dll_005ac0b8 = "advapi32.dll";
+
+// STRING: STRONGHOLDCRUSADER 0x005ac0c8
+char const* const s_gdi32_dll_005ac0c8 = "gdi32.dll";
+
+// STRING: STRONGHOLDCRUSADER 0x005ac0d4
+char const* const s_unicows_dll_005ac0d4 = "unicows.dll";
+
+// STRING: STRONGHOLDCRUSADER 0x005ac0e0
+char const* const s_security_dll_005ac0e0 = "security.dll";
+
+// STRING: STRONGHOLDCRUSADER 0x005ac0f0
+char const* const s_ntdll_dll_005ac0f0 = "ntdll.dll";
+
+// STRING: STRONGHOLDCRUSADER 0x005ac0fc
+char const* const s_LdrUnloadDll_005ac0fc = "LdrUnloadDll";
+
+// STRING: STRONGHOLDCRUSADER 0x005ac10c
+char const* const s_GetCPInfo_005ac10c = "GetCPInfo";
+
+// STRING: STRONGHOLDCRUSADER 0x005ac118
+char const* const s_IsValidCodePage_005ac118 = "IsValidCodePage";
+
+// STRING: STRONGHOLDCRUSADER 0x005ac144
+char const* const s___005ac144 = "*";
+
+// STRING: STRONGHOLDCRUSADER 0x005ac170
+char const* const s_string_too_long_005ac170 = "string too long";
+
+// STRING: STRONGHOLDCRUSADER 0x005ac180
+char const* const s_invalid_string_position_005ac180 = "invalid string position";
+
+// STRING: STRONGHOLDCRUSADER 0x005ac198
+char const* const s_r_005ac198 = "r";
+
+// STRING: STRONGHOLDCRUSADER 0x005ac240
+char const* const s_Unknown_exception_005ac240 = "Unknown exception";
+
+// STRING: STRONGHOLDCRUSADER 0x005ac288
+char const* const s_CorExitProcess_005ac288 = "CorExitProcess";
+
+// STRING: STRONGHOLDCRUSADER 0x005ac298
+char const* const s_mscoree_dll_005ac298 = "mscoree.dll";
+
+// STRING: STRONGHOLDCRUSADER 0x005acab0
+char const* const s_LC_TIME_005acab0 = "LC_TIME";
+
+// STRING: STRONGHOLDCRUSADER 0x005acab8
+char const* const s_LC_NUMERIC_005acab8 = "LC_NUMERIC";
+
+// STRING: STRONGHOLDCRUSADER 0x005acac4
+char const* const s_LC_MONETARY_005acac4 = "LC_MONETARY";
+
+// STRING: STRONGHOLDCRUSADER 0x005acad0
+char const* const s_LC_CTYPE_005acad0 = "LC_CTYPE";
+
+// STRING: STRONGHOLDCRUSADER 0x005acadc
+char const* const s_LC_COLLATE_005acadc = "LC_COLLATE";
+
+// STRING: STRONGHOLDCRUSADER 0x005acbdc
+char const* const s_bad_exception_005acbdc = "bad exception";
+
+// STRING: STRONGHOLDCRUSADER 0x005acbec
+char const* const s_e_000_005acbec = "e+000";
+
+// STRING: STRONGHOLDCRUSADER 0x005acc08
+char const* const s_IsProcessorFeaturePresent_005acc08 = "IsProcessorFeaturePresent";
+
+// STRING: STRONGHOLDCRUSADER 0x005acc24
+char const* const s_KERNEL32_005acc24 = "KERNEL32";
+
+// STRING: STRONGHOLDCRUSADER 0x005acc78
+char const* const s_modf_005acc78 = "modf";
+
+// STRING: STRONGHOLDCRUSADER 0x005acc88
+char const* const s_floor_005acc88 = "floor";
+
+// STRING: STRONGHOLDCRUSADER 0x005acc90
+char const* const s_ceil_005acc90 = "ceil";
+
+// STRING: STRONGHOLDCRUSADER 0x005acc98
+char const* const s_tan_005acc98 = "tan";
+
+// STRING: STRONGHOLDCRUSADER 0x005acc9c
+char const* const s_cos_005acc9c = "cos";
+
+// STRING: STRONGHOLDCRUSADER 0x005acca0
+char const* const s_sin_005acca0 = "sin";
+
+// STRING: STRONGHOLDCRUSADER 0x005accb4
+char const* const s_atan_005accb4 = "atan";
+
+// STRING: STRONGHOLDCRUSADER 0x005accbc
+char const* const s_acos_005accbc = "acos";
+
+// STRING: STRONGHOLDCRUSADER 0x005accc4
+char const* const s_asin_005accc4 = "asin";
+
+// STRING: STRONGHOLDCRUSADER 0x005acce4
+char const* const s_log10_005acce4 = "log10";
+
+// STRING: STRONGHOLDCRUSADER 0x005accec
+char const* const s_log_005accec = "log";
+
+// STRING: STRONGHOLDCRUSADER 0x005accf0
+char const* const s_pow_005accf0 = "pow";
+
+// STRING: STRONGHOLDCRUSADER 0x005accf4
+char const* const s_exp_005accf4 = "exp";
+
+// STRING: STRONGHOLDCRUSADER 0x005af690
+char const* const s_TZ_005af690 = "TZ";
+
+// STRING: STRONGHOLDCRUSADER 0x005af6e4
+char const* const s__null__005af6e4 = "(null)";
+
+// STRING: STRONGHOLDCRUSADER 0x005af754
+char const* const s__mixcrt_005af754 = ".mixcrt";
+
+// STRING: STRONGHOLDCRUSADER 0x005af75c
+char const* const s_EncodePointer_005af75c = "EncodePointer";
+
+// STRING: STRONGHOLDCRUSADER 0x005af76c
+char const* const s_KERNEL32_DLL_005af76c = "KERNEL32.DLL";
+
+// STRING: STRONGHOLDCRUSADER 0x005af77c
+char const* const s_DecodePointer_005af77c = "DecodePointer";
+
+// STRING: STRONGHOLDCRUSADER 0x005af78c
+char const* const s_FlsFree_005af78c = "FlsFree";
+
+// STRING: STRONGHOLDCRUSADER 0x005af794
+char const* const s_FlsSetValue_005af794 = "FlsSetValue";
+
+// STRING: STRONGHOLDCRUSADER 0x005af7a0
+char const* const s_FlsGetValue_005af7a0 = "FlsGetValue";
+
+// STRING: STRONGHOLDCRUSADER 0x005af7ac
+char const* const s_FlsAlloc_005af7ac = "FlsAlloc";
+
+// STRING: STRONGHOLDCRUSADER 0x005afcbc
+char const* const s_R6008___not_enough_space_for_arg_005afcbc = "R6008\r\n- not enough space for arguments\r\n";
+
+// STRING: STRONGHOLDCRUSADER 0x005afd18
+char const* const s_Microsoft_Visual_C__Runtime_Lib_005afd18 = "Microsoft Visual C++ Runtime Library";
+
+// STRING: STRONGHOLDCRUSADER 0x005afd40
+char const* const s__005afd40 = "\n\n";
+
+// STRING: STRONGHOLDCRUSADER 0x005afd44
+char const* const s__program_name_unknown__005afd44 = "<program name unknown>";
+
+// STRING: STRONGHOLDCRUSADER 0x005afd5c
+char const* const s_Runtime_Error__Program__005afd5c = "Runtime Error!\n\nProgram: ";
+
+// STRING: STRONGHOLDCRUSADER 0x005afd78
+char const* const s_ccs__005afd78 = "ccs=";
+
+// STRING: STRONGHOLDCRUSADER 0x005afd80
+char const* const s_UTF_8_005afd80 = "UTF-8";
+
+// STRING: STRONGHOLDCRUSADER 0x005afd88
+char const* const s_UTF_16LE_005afd88 = "UTF-16LE";
+
+// STRING: STRONGHOLDCRUSADER 0x005afd94
+char const* const s_UNICODE_005afd94 = "UNICODE";
+
+// STRING: STRONGHOLDCRUSADER 0x005afd9c
+char const* const s_InitializeCriticalSectionAndSpin_005afd9c = "InitializeCriticalSectionAndSpinCount";
+
+// STRING: STRONGHOLDCRUSADER 0x005afdc4
+char const* const s_HH_mm_ss_005afdc4 = "HH:mm:ss";
+
+// STRING: STRONGHOLDCRUSADER 0x005afdd0
+char const* const s_dddd__MMMM_dd__yyyy_005afdd0 = "dddd, MMMM dd, yyyy";
+
+// STRING: STRONGHOLDCRUSADER 0x005afde4
+char const* const s_MM_dd_yy_005afde4 = "MM/dd/yy";
+
+// STRING: STRONGHOLDCRUSADER 0x005afdf0
+char const* const s_PM_005afdf0 = "PM";
+
+// STRING: STRONGHOLDCRUSADER 0x005afdf4
+char const* const s_AM_005afdf4 = "AM";
+
+// STRING: STRONGHOLDCRUSADER 0x005afdf8
+char const* const s_December_005afdf8 = "December";
+
+// STRING: STRONGHOLDCRUSADER 0x005afe04
+char const* const s_November_005afe04 = "November";
+
+// STRING: STRONGHOLDCRUSADER 0x005afe10
+char const* const s_October_005afe10 = "October";
+
+// STRING: STRONGHOLDCRUSADER 0x005afe18
+char const* const s_September_005afe18 = "September";
+
+// STRING: STRONGHOLDCRUSADER 0x005afe24
+char const* const s_August_005afe24 = "August";
+
+// STRING: STRONGHOLDCRUSADER 0x005afe2c
+char const* const s_July_005afe2c = "July";
+
+// STRING: STRONGHOLDCRUSADER 0x005afe34
+char const* const s_June_005afe34 = "June";
+
+// STRING: STRONGHOLDCRUSADER 0x005afe3c
+char const* const s_April_005afe3c = "April";
+
+// STRING: STRONGHOLDCRUSADER 0x005afe44
+char const* const s_March_005afe44 = "March";
+
+// STRING: STRONGHOLDCRUSADER 0x005afe4c
+char const* const s_February_005afe4c = "February";
+
+// STRING: STRONGHOLDCRUSADER 0x005afe58
+char const* const s_January_005afe58 = "January";
+
+// STRING: STRONGHOLDCRUSADER 0x005afe60
+char const* const s_Dec_005afe60 = "Dec";
+
+// STRING: STRONGHOLDCRUSADER 0x005afe64
+char const* const s_Nov_005afe64 = "Nov";
+
+// STRING: STRONGHOLDCRUSADER 0x005afe68
+char const* const s_Oct_005afe68 = "Oct";
+
+// STRING: STRONGHOLDCRUSADER 0x005afe6c
+char const* const s_Sep_005afe6c = "Sep";
+
+// STRING: STRONGHOLDCRUSADER 0x005afe70
+char const* const s_Aug_005afe70 = "Aug";
+
+// STRING: STRONGHOLDCRUSADER 0x005afe74
+char const* const s_Jul_005afe74 = "Jul";
+
+// STRING: STRONGHOLDCRUSADER 0x005afe78
+char const* const s_Jun_005afe78 = "Jun";
+
+// STRING: STRONGHOLDCRUSADER 0x005afe7c
+char const* const s_May_005afe7c = "May";
+
+// STRING: STRONGHOLDCRUSADER 0x005afe80
+char const* const s_Apr_005afe80 = "Apr";
+
+// STRING: STRONGHOLDCRUSADER 0x005afe84
+char const* const s_Mar_005afe84 = "Mar";
+
+// STRING: STRONGHOLDCRUSADER 0x005afe88
+char const* const s_Feb_005afe88 = "Feb";
+
+// STRING: STRONGHOLDCRUSADER 0x005afe8c
+char const* const s_Jan_005afe8c = "Jan";
+
+// STRING: STRONGHOLDCRUSADER 0x005afe90
+char const* const s_Saturday_005afe90 = "Saturday";
+
+// STRING: STRONGHOLDCRUSADER 0x005afe9c
+char const* const s_Friday_005afe9c = "Friday";
+
+// STRING: STRONGHOLDCRUSADER 0x005afea4
+char const* const s_Thursday_005afea4 = "Thursday";
+
+// STRING: STRONGHOLDCRUSADER 0x005afeb0
+char const* const s_Wednesday_005afeb0 = "Wednesday";
+
+// STRING: STRONGHOLDCRUSADER 0x005afebc
+char const* const s_Tuesday_005afebc = "Tuesday";
+
+// STRING: STRONGHOLDCRUSADER 0x005afec4
+char const* const s_Monday_005afec4 = "Monday";
+
+// STRING: STRONGHOLDCRUSADER 0x005afecc
+char const* const s_Sunday_005afecc = "Sunday";
+
+// STRING: STRONGHOLDCRUSADER 0x005afed4
+char const* const s_Sat_005afed4 = "Sat";
+
+// STRING: STRONGHOLDCRUSADER 0x005afed8
+char const* const s_Fri_005afed8 = "Fri";
+
+// STRING: STRONGHOLDCRUSADER 0x005afedc
+char const* const s_Thu_005afedc = "Thu";
+
+// STRING: STRONGHOLDCRUSADER 0x005afee0
+char const* const s_Wed_005afee0 = "Wed";
+
+// STRING: STRONGHOLDCRUSADER 0x005afee4
+char const* const s_Tue_005afee4 = "Tue";
+
+// STRING: STRONGHOLDCRUSADER 0x005afee8
+char const* const s_Mon_005afee8 = "Mon";
+
+// STRING: STRONGHOLDCRUSADER 0x005afeec
+char const* const s_Sun_005afeec = "Sun";
+
+// STRING: STRONGHOLDCRUSADER 0x005affd4
+char const* const s_britain_005affd4 = "britain";
+
+// STRING: STRONGHOLDCRUSADER 0x005affdc
+char const* const s_america_005affdc = "america";
+
+// STRING: STRONGHOLDCRUSADER 0x005affe8
+char const* const s_us_005affe8 = "us";
+
+// STRING: STRONGHOLDCRUSADER 0x005b00bc
+char const* const s_spanish_guatemala_005b00bc = "spanish-guatemala";
+
+// STRING: STRONGHOLDCRUSADER 0x005b00d0
+char const* const s_spanish_el_salvador_005b00d0 = "spanish-el salvador";
+
+// STRING: STRONGHOLDCRUSADER 0x005b00e4
+char const* const s_spanish_ecuador_005b00e4 = "spanish-ecuador";
+
+// STRING: STRONGHOLDCRUSADER 0x005b00f4
+char const* const s_spanish_dominican_republic_005b00f4 = "spanish-dominican republic";
+
+// STRING: STRONGHOLDCRUSADER 0x005b0344
+char const* const s_chinese_traditional_005b0344 = "chinese-traditional";
+
+// STRING: STRONGHOLDCRUSADER 0x005b0358
+char const* const s_chinese_singapore_005b0358 = "chinese-singapore";
+
+// STRING: STRONGHOLDCRUSADER 0x005b036c
+char const* const s_chinese_simplified_005b036c = "chinese-simplified";
+
+// STRING: STRONGHOLDCRUSADER 0x005b0380
+char const* const s_chinese_hongkong_005b0380 = "chinese-hongkong";
+
+// STRING: STRONGHOLDCRUSADER 0x005b0394
+char const* const s_chinese_005b0394 = "chinese";
+
+// STRING: STRONGHOLDCRUSADER 0x005b039c
+char const* const s_chi_005b039c = "chi";
+
+// STRING: STRONGHOLDCRUSADER 0x005b03a0
+char const* const s_chh_005b03a0 = "chh";
+
+// STRING: STRONGHOLDCRUSADER 0x005b03a4
+char const* const s_canadian_005b03a4 = "canadian";
+
+// STRING: STRONGHOLDCRUSADER 0x005b03b0
+char const* const s_belgian_005b03b0 = "belgian";
+
+// STRING: STRONGHOLDCRUSADER 0x005b03b8
+char const* const s_australian_005b03b8 = "australian";
+
+// STRING: STRONGHOLDCRUSADER 0x005b03c4
+char const* const s_american_english_005b03c4 = "american-english";
+
+// STRING: STRONGHOLDCRUSADER 0x005b03d8
+char const* const s_american_english_005b03d8 = "american english";
+
+// STRING: STRONGHOLDCRUSADER 0x005b06c4
+char const* const s_OCP_005b06c4 = "OCP";
+
+// STRING: STRONGHOLDCRUSADER 0x005b06c8
+char const* const s_ACP_005b06c8 = "ACP";
+
+// STRING: STRONGHOLDCRUSADER 0x005b06cc
+char const* const s_Norwegian_Nynorsk_005b06cc = "Norwegian-Nynorsk";
+
+// STRING: STRONGHOLDCRUSADER 0x005b0788
+char const* const s_exp10_005b0788 = "exp10";
+
+// STRING: STRONGHOLDCRUSADER 0x005b1ffc
+char const* const s_GetProcessWindowStation_005b1ffc = "GetProcessWindowStation";
+
+// STRING: STRONGHOLDCRUSADER 0x005b2014
+char const* const s_GetUserObjectInformationA_005b2014 = "GetUserObjectInformationA";
+
+// STRING: STRONGHOLDCRUSADER 0x005b2030
+char const* const s_GetLastActivePopup_005b2030 = "GetLastActivePopup";
+
+// STRING: STRONGHOLDCRUSADER 0x005b2044
+char const* const s_GetActiveWindow_005b2044 = "GetActiveWindow";
+
+// STRING: STRONGHOLDCRUSADER 0x005b2054
+char const* const s_MessageBoxA_005b2054 = "MessageBoxA";
+
+// STRING: STRONGHOLDCRUSADER 0x005b2060
+char const* const s_USER32_DLL_005b2060 = "USER32.DLL";
+
+// STRING: STRONGHOLDCRUSADER 0x005b206c
+char const* const s_Complete_Object_Locator__005b206c = " Complete Object Locator'";
+
+// STRING: STRONGHOLDCRUSADER 0x005b2088
+char const* const s_Class_Hierarchy_Descriptor__005b2088 = " Class Hierarchy Descriptor'";
+
+// STRING: STRONGHOLDCRUSADER 0x005b20a8
+char const* const s_Base_Class_Array__005b20a8 = " Base Class Array'";
+
+// STRING: STRONGHOLDCRUSADER 0x005b20bc
+char const* const s_Base_Class_Descriptor_at___005b20bc = " Base Class Descriptor at (";
+
+// STRING: STRONGHOLDCRUSADER 0x005b20d8
+char const* const s_Type_Descriptor__005b20d8 = " Type Descriptor'";
+
+// STRING: STRONGHOLDCRUSADER 0x005b20ec
+char const* const s__local_static_thread_guard__005b20ec = "`local static thread guard'";
+
+// STRING: STRONGHOLDCRUSADER 0x005b2108
+char const* const s__managed_vector_copy_constructor_005b2108 = "`managed vector copy constructor iterator'";
+
+// STRING: STRONGHOLDCRUSADER 0x005b2134
+char const* const s__vector_vbase_copy_constructor_i_005b2134 = "`vector vbase copy constructor iterator'";
+
+// STRING: STRONGHOLDCRUSADER 0x005b2160
+char const* const s__vector_copy_constructor_iterato_005b2160 = "`vector copy constructor iterator'";
+
+// STRING: STRONGHOLDCRUSADER 0x005b2184
+char const* const s__dynamic_atexit_destructor_for___005b2184 = "`dynamic atexit destructor for '";
+
+// STRING: STRONGHOLDCRUSADER 0x005b21a8
+char const* const s__dynamic_initializer_for___005b21a8 = "`dynamic initializer for '";
+
+// STRING: STRONGHOLDCRUSADER 0x005b21c4
+char const* const s__eh_vector_vbase_copy_constructo_005b21c4 = "`eh vector vbase copy constructor iterator'";
+
+// STRING: STRONGHOLDCRUSADER 0x005b21f0
+char const* const s__eh_vector_copy_constructor_iter_005b21f0 = "`eh vector copy constructor iterator'";
+
+// STRING: STRONGHOLDCRUSADER 0x005b2218
+char const* const s__managed_vector_destructor_itera_005b2218 = "`managed vector destructor iterator'";
+
+// STRING: STRONGHOLDCRUSADER 0x005b2240
+char const* const s__managed_vector_constructor_iter_005b2240 = "`managed vector constructor iterator'";
+
+// STRING: STRONGHOLDCRUSADER 0x005b2268
+char const* const s__placement_delete__closure__005b2268 = "`placement delete[] closure'";
+
+// STRING: STRONGHOLDCRUSADER 0x005b2288
+char const* const s__placement_delete_closure__005b2288 = "`placement delete closure'";
+
+// STRING: STRONGHOLDCRUSADER 0x005b22a4
+char const* const s__omni_callsig__005b22a4 = "`omni callsig'";
+
+// STRING: STRONGHOLDCRUSADER 0x005b22b4
+char const* const s_delete__005b22b4 = " delete[]";
+
+// STRING: STRONGHOLDCRUSADER 0x005b22c0
+char const* const s_new__005b22c0 = " new[]";
+
+// STRING: STRONGHOLDCRUSADER 0x005b22c8
+char const* const s__local_vftable_constructor_closu_005b22c8 = "`local vftable constructor closure'";
+
+// STRING: STRONGHOLDCRUSADER 0x005b22ec
+char const* const s__local_vftable__005b22ec = "`local vftable'";
+
+// STRING: STRONGHOLDCRUSADER 0x005b22fc
+char const* const s__RTTI_005b22fc = "`RTTI";
+
+// STRING: STRONGHOLDCRUSADER 0x005b2304
+char const* const s__EH_005b2304 = "`EH";
+
+// STRING: STRONGHOLDCRUSADER 0x005b2308
+char const* const s__udt_returning__005b2308 = "`udt returning'";
+
+// STRING: STRONGHOLDCRUSADER 0x005b2318
+char const* const s__copy_constructor_closure__005b2318 = "`copy constructor closure'";
+
+// STRING: STRONGHOLDCRUSADER 0x005b2334
+char const* const s__eh_vector_vbase_constructor_ite_005b2334 = "`eh vector vbase constructor iterator'";
+
+// STRING: STRONGHOLDCRUSADER 0x005b235c
+char const* const s__eh_vector_destructor_iterator__005b235c = "`eh vector destructor iterator'";
+
+// STRING: STRONGHOLDCRUSADER 0x005b237c
+char const* const s__eh_vector_constructor_iterator__005b237c = "`eh vector constructor iterator'";
+
+// STRING: STRONGHOLDCRUSADER 0x005b23a0
+char const* const s__virtual_displacement_map__005b23a0 = "`virtual displacement map'";
+
+// STRING: STRONGHOLDCRUSADER 0x005b23bc
+char const* const s__vector_vbase_constructor_iterat_005b23bc = "`vector vbase constructor iterator'";
+
+// STRING: STRONGHOLDCRUSADER 0x005b23e0
+char const* const s__vector_destructor_iterator__005b23e0 = "`vector destructor iterator'";
+
+// STRING: STRONGHOLDCRUSADER 0x005b2400
+char const* const s__vector_constructor_iterator__005b2400 = "`vector constructor iterator'";
+
+// STRING: STRONGHOLDCRUSADER 0x005b2420
+char const* const s__scalar_deleting_destructor__005b2420 = "`scalar deleting destructor'";
+
+// STRING: STRONGHOLDCRUSADER 0x005b2440
+char const* const s__default_constructor_closure__005b2440 = "`default constructor closure'";
+
+// STRING: STRONGHOLDCRUSADER 0x005b2460
+char const* const s__vector_deleting_destructor__005b2460 = "`vector deleting destructor'";
+
+// STRING: STRONGHOLDCRUSADER 0x005b2480
+char const* const s__vbase_destructor__005b2480 = "`vbase destructor'";
+
+// STRING: STRONGHOLDCRUSADER 0x005b2494
+char const* const s__string__005b2494 = "`string'";
+
+// STRING: STRONGHOLDCRUSADER 0x005b24a0
+char const* const s__local_static_guard__005b24a0 = "`local static guard'";
+
+// STRING: STRONGHOLDCRUSADER 0x005b24b8
+char const* const s__typeof__005b24b8 = "`typeof'";
+
+// STRING: STRONGHOLDCRUSADER 0x005b24c4
+char const* const s__vcall__005b24c4 = "`vcall'";
+
+// STRING: STRONGHOLDCRUSADER 0x005b24cc
+char const* const s__vbtable__005b24cc = "`vbtable'";
+
+// STRING: STRONGHOLDCRUSADER 0x005b24d8
+char const* const s__vftable__005b24d8 = "`vftable'";
+
+// STRING: STRONGHOLDCRUSADER 0x005b24e4
+char const* const s___005b24e4 = "^=";
+
+// STRING: STRONGHOLDCRUSADER 0x005b24e8
+char const* const s___005b24e8 = "|=";
+
+// STRING: STRONGHOLDCRUSADER 0x005b24ec
+char const* const s___005b24ec = "&=";
+
+// STRING: STRONGHOLDCRUSADER 0x005b24f0
+char const* const s___005b24f0 = "<<=";
+
+// STRING: STRONGHOLDCRUSADER 0x005b24f4
+char const* const s___005b24f4 = ">>=";
+
+// STRING: STRONGHOLDCRUSADER 0x005b24f8
+char const* const s___005b24f8 = "%=";
+
+// STRING: STRONGHOLDCRUSADER 0x005b24fc
+char const* const s___005b24fc = "/=";
+
+// STRING: STRONGHOLDCRUSADER 0x005b2500
+char const* const s___005b2500 = "-=";
+
+// STRING: STRONGHOLDCRUSADER 0x005b2504
+char const* const s___005b2504 = "+=";
+
+// STRING: STRONGHOLDCRUSADER 0x005b2508
+char const* const s___005b2508 = "*=";
+
+// STRING: STRONGHOLDCRUSADER 0x005b250c
+char const* const s___005b250c = "||";
+
+// STRING: STRONGHOLDCRUSADER 0x005b2510
+char const* const s___005b2510 = "&&";
+
+// STRING: STRONGHOLDCRUSADER 0x005b2514
+char const* const s___005b2514 = "|";
+
+// STRING: STRONGHOLDCRUSADER 0x005b2518
+char const* const s___005b2518 = "^";
+
+// STRING: STRONGHOLDCRUSADER 0x005b251c
+char const* const s___005b251c = "~";
+
+// STRING: STRONGHOLDCRUSADER 0x005b2520
+char const* const s___005b2520 = "()";
+
+// STRING: STRONGHOLDCRUSADER 0x005b2524
+char const* const s___005b2524 = ",";
+
+// STRING: STRONGHOLDCRUSADER 0x005b2528
+char const* const s___005b2528 = ">=";
+
+// STRING: STRONGHOLDCRUSADER 0x005b252c
+char const* const s___005b252c = ">";
+
+// STRING: STRONGHOLDCRUSADER 0x005b2530
+char const* const s___005b2530 = "<=";
+
+// STRING: STRONGHOLDCRUSADER 0x005b2534
+char const* const s___005b2534 = "<";
+
+// STRING: STRONGHOLDCRUSADER 0x005b2538
+char const* const s___005b2538 = "->*";
+
+// STRING: STRONGHOLDCRUSADER 0x005b253c
+char const* const s___005b253c = "&";
+
+// STRING: STRONGHOLDCRUSADER 0x005b2540
+char const* const s___005b2540 = "+";
+
+// STRING: STRONGHOLDCRUSADER 0x005b2544
+char const* const s___005b2544 = "--";
+
+// STRING: STRONGHOLDCRUSADER 0x005b2548
+char const* const s___005b2548 = "++";
+
+// STRING: STRONGHOLDCRUSADER 0x005b254c
+char const* const s___005b254c = "->";
+
+// STRING: STRONGHOLDCRUSADER 0x005b2550
+char const* const s_operator_005b2550 = "operator";
+
+// STRING: STRONGHOLDCRUSADER 0x005b255c
+char const* const s___005b255c = "[]";
+
+// STRING: STRONGHOLDCRUSADER 0x005b2560
+char const* const s___005b2560 = "!=";
+
+// STRING: STRONGHOLDCRUSADER 0x005b2564
+char const* const s___005b2564 = "==";
+
+// STRING: STRONGHOLDCRUSADER 0x005b2568
+char const* const s___005b2568 = "<<";
+
+// STRING: STRONGHOLDCRUSADER 0x005b256c
+char const* const s___005b256c = ">>";
+
+// STRING: STRONGHOLDCRUSADER 0x005b2570
+char const* const s_delete_005b2570 = " delete";
+
+// STRING: STRONGHOLDCRUSADER 0x005b2578
+char const* const s_new_005b2578 = " new";
+
+// STRING: STRONGHOLDCRUSADER 0x005b2580
+char const* const s___unaligned_005b2580 = "__unaligned";
+
+// STRING: STRONGHOLDCRUSADER 0x005b258c
+char const* const s___restrict_005b258c = "__restrict";
+
+// STRING: STRONGHOLDCRUSADER 0x005b2598
+char const* const s___ptr64_005b2598 = "__ptr64";
+
+// STRING: STRONGHOLDCRUSADER 0x005b25a0
+char const* const s___clrcall_005b25a0 = "__clrcall";
+
+// STRING: STRONGHOLDCRUSADER 0x005b25ac
+char const* const s___fastcall_005b25ac = "__fastcall";
+
+// STRING: STRONGHOLDCRUSADER 0x005b25b8
+char const* const s___thiscall_005b25b8 = "__thiscall";
+
+// STRING: STRONGHOLDCRUSADER 0x005b25c4
+char const* const s___stdcall_005b25c4 = "__stdcall";
+
+// STRING: STRONGHOLDCRUSADER 0x005b25d0
+char const* const s___pascal_005b25d0 = "__pascal";
+
+// STRING: STRONGHOLDCRUSADER 0x005b25dc
+char const* const s___cdecl_005b25dc = "__cdecl";
+
+// STRING: STRONGHOLDCRUSADER 0x005b25e4
+char const* const s___based__005b25e4 = "__based(";
+
+// STRING: STRONGHOLDCRUSADER 0x005b2770
+char const* const s_CONOUT__005b2770 = "CONOUT$";
+
+// STRING: STRONGHOLDCRUSADER 0x005b2778
+char const* const s_1_QNAN_005b2778 = "1#QNAN";
+
+// STRING: STRONGHOLDCRUSADER 0x005b2780
+char const* const s_1_INF_005b2780 = "1#INF";
+
+// STRING: STRONGHOLDCRUSADER 0x005b2788
+char const* const s_1_IND_005b2788 = "1#IND";
+
+// STRING: STRONGHOLDCRUSADER 0x005b2790
+char const* const s_1_SNAN_005b2790 = "1#SNAN";
+
+// STRING: STRONGHOLDCRUSADER 0x005b2798
+char const* const s_LCMapStringW_005b2798 = "LCMapStringW";
+
+// STRING: STRONGHOLDCRUSADER 0x005b27a8
+char const* const s_CreateFileW_005b27a8 = "CreateFileW";
+
+// STRING: STRONGHOLDCRUSADER 0x005b27b4
+char const* const s_WriteConsoleW_005b27b4 = "WriteConsoleW";
+
+// STRING: STRONGHOLDCRUSADER 0x005b27c4
+char const* const s_FreeEnvironmentStringsW_005b27c4 = "FreeEnvironmentStringsW";
+
+// STRING: STRONGHOLDCRUSADER 0x005b27dc
+char const* const s_GetEnvironmentStringsW_005b27dc = "GetEnvironmentStringsW";
+
+// STRING: STRONGHOLDCRUSADER 0x005b27f4
+char const* const s_GetStringTypeW_005b27f4 = "GetStringTypeW";
+
+// STRING: STRONGHOLDCRUSADER 0x005b2804
+char const* const s_GetLocaleInfoW_005b2804 = "GetLocaleInfoW";
+
+// STRING: STRONGHOLDCRUSADER 0x005b2814
+char const* const s_CompareStringW_005b2814 = "CompareStringW";
+
+// STRING: STRONGHOLDCRUSADER 0x00b932a0
+char const* const LIB_pkware_InfoString
+    = "PKWARE Data Compression Library for Win32\r\nCopyright 1989-1995 PKWARE Inc.  All Rights Reserved\r\nPatent No. "
+      "5,051,745\r\nPKWARE Data Compression Library Reg. U.S. Pat. and Tm. Off.\r\nVersion 1.11";

--- a/tools/mcp/ghidra_scripts/stringexporter.py
+++ b/tools/mcp/ghidra_scripts/stringexporter.py
@@ -1,5 +1,6 @@
-#TODO write a description for this script
-#@author 
+#This script exports .rdata literal strings and addresses into a file. 
+# Labels are either default Ghidra labels or labels set by users.
+#@author Gynt
 #@category _OPENSHC.TOOLS.DECOMPILATION
 #@keybinding 
 #@menupath 
@@ -7,7 +8,6 @@
 #@runtime Jython
 
 
-#TODO Add User Code Here
 
 import re
 PATTERN = re.compile("[^a-zA-Z0-9_]+")

--- a/tools/mcp/ghidra_scripts/stringexporter.py
+++ b/tools/mcp/ghidra_scripts/stringexporter.py
@@ -1,0 +1,31 @@
+#TODO write a description for this script
+#@author 
+#@category _OPENSHC.TOOLS.DECOMPILATION
+#@keybinding 
+#@menupath 
+#@toolbar 
+#@runtime Jython
+
+
+#TODO Add User Code Here
+
+import re
+PATTERN = re.compile("[^a-zA-Z0-9_]+")
+
+
+l = getCurrentProgram().getListing()
+roRange = getCurrentProgram().getMemory().getBlocks()[2].getAddressRange()
+
+sdump = ""
+
+cur = l.getCodeUnitAt(roRange.getMinAddress())
+while cur.getAddress() < roRange.getMaxAddress():
+	while cur.getDataType().toString() != "string":
+		cur = l.getCodeUnitAfter(cur.getAddress())
+	if cur.getLabel():
+		sdump += "// STRING: STRONGHOLDCRUSADER 0x00" + hex(cur.getAddress().getOffset())[2:-1] + "\n"
+		sdump += "char const * const " + PATTERN.sub("_", cur.getLabel()) + ' = "' + cur.getValue().replace("\\", "\\\\").replace("\n", "\\n").replace("\r", "\\r").replace('"', '\\"') + '";' + "\n\n"
+	cur = l.getCodeUnitAfter(cur.getAddress())
+
+with open(str(askFile("dump file", "select")), "w") as f:
+	f.write(sdump)


### PR DESCRIPTION
Resolves #52 by exporting literal strings and their address from Ghidra into a file, listing strings by address. Ready for usage in OpenSHC by including said file.
