### PR TITLE
Refactor windows lib functions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -163,7 +163,7 @@ target_file_copy_if_different(OpenSHC.exe.runnable "${CRUSADER_DIR}/shfolder.dll
 add_library(OpenSHC.dll SHARED src/entry.cpp ${CORE_SOURCES} ${OPENSHC_SOURCES})
 set_target_properties(OpenSHC.dll PROPERTIES OUTPUT_NAME ${OPEN_SHC_NAME})
 set_target_properties(OpenSHC.dll PROPERTIES RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/DLL")
-target_compile_definitions(OpenSHC.dll PRIVATE OPEN_SHC_DLL)
+target_compile_definitions(OpenSHC.dll PRIVATE OPEN_SHC_DLL REIMPLEMENTED_CRT=0)
 target_precompile_headers(OpenSHC.dll PRIVATE $<$<COMPILE_LANGUAGE:CXX>:${PCH_FILE}>)
 
 

--- a/src/OpenSHC/Audio/SoundEffectsHelperData1.hpp
+++ b/src/OpenSHC/Audio/SoundEffectsHelperData1.hpp
@@ -37,14 +37,14 @@ namespace Audio {
         int DAT_RandomVariationCurrentPlayingMusic_02; // 0x00000048 length: 4
         undefined4 field12_0x4c; // 0x0000004C length: 4
         undefined4 field13_0x50; // 0x00000050 length: 4
-        undefined1 padding_0x54[4]; // 0x00000054 length: 4
-        BOOLEnum field18_0x58; // 0x00000058 length: 4
-        undefined4 field19_0x5c; // 0x0000005C length: 4
+        BOOLEnum field14_0x54; // 0x00000054 length: 4
+        BOOLEnum field15_0x58; // 0x00000058 length: 4
+        undefined4 field16_0x5c; // 0x0000005C length: 4
         undefined4 DAT_WinMusicVariation; // 0x00000060 length: 4
-        undefined4 field21_0x64; // 0x00000064 length: 4
+        undefined4 field18_0x64; // 0x00000064 length: 4
         undefined4 DAT_LossMusicVariation; // 0x00000068 length: 4
         DWORD DAT_enemyInsideCastleSoundWarningCooldownTimer; // 0x0000006C length: 4
-        undefined4 field24_0x70; // 0x00000070 length: 4
+        undefined4 field21_0x70; // 0x00000070 length: 4
         WAVEFORMATEX SND_Waveformat; // 0x00000074 length: 18
         undefined1 padding_0x86[2]; // 0x00000086 length: 2
 

--- a/src/OpenSHC/Global.func.hpp
+++ b/src/OpenSHC/Global.func.hpp
@@ -1299,10 +1299,6 @@ namespace Global_Func {
     SetRNGSeed;
 
     MACRO_FUNCTION_RESOLVER(
-        char*(__cdecl*)(char* string), false, Address::SHC_3BB0A8C1_0x005818EB, &OpenSHC::Global::StringToLowerCase)
-    StringToLowerCase;
-
-    MACRO_FUNCTION_RESOLVER(
         int(__cdecl*)(HANDLE hFile), false, Address::SHC_3BB0A8C1_0x005826FB, &OpenSHC::Global::GetFilePtrPos)
     GetFilePtrPos;
 

--- a/src/OpenSHC/Global.hpp
+++ b/src/OpenSHC/Global.hpp
@@ -697,8 +697,6 @@ namespace Global {
 
     void __cdecl SetRNGSeed(ulong param_1);
 
-    char* __cdecl StringToLowerCase(char* string);
-
     int __cdecl GetFilePtrPos(HANDLE hFile);
 
 } // namespace Global

--- a/src/OpenSHC/OS.func.hpp
+++ b/src/OpenSHC/OS.func.hpp
@@ -1,0 +1,234 @@
+/**
+  THIS FILE IS AUTO GENERATED
+  Communicate changes to the dev team (e.g. via a Pull Request).
+  Changes get lost otherwise.
+
+  path: 'OpenSHC/OS.func.hpp'
+*/
+
+#pragma once
+
+#include "OpenSHC/OS.hpp"
+#include "OpenSHC/WindowsHelper/Enums/BOOLEnum.hpp"
+#include "OpenSHC/WindowsHelper/Enums/FilePtrMoveMethodInt.hpp"
+#include "OpenSHC/WindowsHelper/Enums/OpenFlagInt.hpp"
+#include "crtdefs.h"
+#include "guiddef.h"
+#include "mbstring.h"
+#include "time.h"
+#include "vadefs.h"
+namespace OpenSHC {
+namespace OS_Func {
+
+    using OpenSHC::WindowsHelper::Enums::BOOLEnum;
+    using OpenSHC::WindowsHelper::Enums::FilePtrMoveMethodInt;
+    using OpenSHC::WindowsHelper::Enums::OpenFlagInt;
+
+    MACRO_FUNCTION_RESOLVER(int*(__stdcall*)(void* param_1, uint param_2), REIMPLEMENTED_CRT,
+        Address::SHC_3BB0A8C1_0x004791B0, &OpenSHC::OS::basic_ofstream_write)
+    basic_ofstream_write;
+
+    MACRO_FUNCTION_RESOLVER(BOOLEnum(__cdecl*)(GUID* param_1, GUID* param_2), REIMPLEMENTED_CRT,
+        Address::SHC_3BB0A8C1_0x0047C5D0, &OpenSHC::OS::isEqualGUID)
+    isEqualGUID;
+
+    MACRO_FUNCTION_RESOLVER(
+        int(__cdecl*)(double _X), REIMPLEMENTED_CRT, Address::SHC_3BB0A8C1_0x0057ECF1, &OpenSHC::OS::__isnan)
+    __isnan;
+
+    MACRO_FUNCTION_RESOLVER(
+        int(__cdecl*)(float10 param), REIMPLEMENTED_CRT, Address::SHC_3BB0A8C1_0x0057ED20, &OpenSHC::OS::__ftol2)
+    __ftol2;
+
+    MACRO_FUNCTION_RESOLVER(void(__cdecl*)(float10 param_1), REIMPLEMENTED_CRT, Address::SHC_3BB0A8C1_0x0057EE10,
+        &OpenSHC::OS::math_atan_FUN_0057ee10)
+    math_atan_FUN_0057ee10;
+
+    MACRO_FUNCTION_RESOLVER(float10(__cdecl*)(float10 floatIn, uint eaxIn, int param_3, int param_4), REIMPLEMENTED_CRT,
+        Address::SHC_3BB0A8C1_0x0057EE68, &OpenSHC::OS::math_atan_FUN_0057ee68)
+    math_atan_FUN_0057ee68;
+
+    MACRO_FUNCTION_RESOLVER(float10(__cdecl*)(float10 param_1), REIMPLEMENTED_CRT, Address::SHC_3BB0A8C1_0x0057EEF0,
+        &OpenSHC::OS::math_sqrt_FUN_0057eef0)
+    math_sqrt_FUN_0057eef0;
+
+    MACRO_FUNCTION_RESOLVER(float10(__cdecl*)(int param_1, uint param_2, float10 param_3), REIMPLEMENTED_CRT,
+        Address::SHC_3BB0A8C1_0x0057EF0D, &OpenSHC::OS::math_sqrt_FUN_0057ef0d)
+    math_sqrt_FUN_0057ef0d;
+
+    MACRO_FUNCTION_RESOLVER(void(__cdecl*)(float10 param_1), REIMPLEMENTED_CRT, Address::SHC_3BB0A8C1_0x0057EFF0,
+        &OpenSHC::OS::math_tan_1_FUN_0057eff0)
+    math_tan_1_FUN_0057eff0;
+
+    MACRO_FUNCTION_RESOLVER(float10(__cdecl*)(int param_1, int param_2), REIMPLEMENTED_CRT,
+        Address::SHC_3BB0A8C1_0x0057F048, &OpenSHC::OS::math_FUN_0057f048)
+    math_FUN_0057f048;
+
+    MACRO_FUNCTION_RESOLVER(float10(__fastcall*)(float10 param_1), REIMPLEMENTED_CRT, Address::SHC_3BB0A8C1_0x0057F120,
+        &OpenSHC::OS::math_cos)
+    math_cos;
+
+    MACRO_FUNCTION_RESOLVER(float10(__fastcall*)(float10 param_1), REIMPLEMENTED_CRT, Address::SHC_3BB0A8C1_0x0057F250,
+        &OpenSHC::OS::math_sin)
+    math_sin;
+
+    MACRO_FUNCTION_RESOLVER(tm*(__cdecl*)(__time32_t * _Time), REIMPLEMENTED_CRT, Address::SHC_3BB0A8C1_0x0057F5FE,
+        &OpenSHC::OS::__localtime64)
+    __localtime64;
+
+    MACRO_FUNCTION_RESOLVER(__time64_t(__cdecl*)(__time64_t* _Time), REIMPLEMENTED_CRT,
+        Address::SHC_3BB0A8C1_0x0057F622, &OpenSHC::OS::__time64)
+    __time64;
+
+    MACRO_FUNCTION_RESOLVER(void*(__cdecl*)(void* _Dst, int _Val, size_t _Size), REIMPLEMENTED_CRT,
+        Address::SHC_3BB0A8C1_0x0057F660, &OpenSHC::OS::_memset)
+    _memset;
+
+    MACRO_FUNCTION_RESOLVER(int(__cdecl*)(char* _Dest, char* _Format), REIMPLEMENTED_CRT,
+        Address::SHC_3BB0A8C1_0x0057F6DA, &OpenSHC::OS::_sprintf)
+    _sprintf;
+
+    MACRO_FUNCTION_RESOLVER(int(__cdecl*)(char* _Str1, char* _Str2), REIMPLEMENTED_CRT,
+        Address::SHC_3BB0A8C1_0x0057F8EE, &OpenSHC::OS::__stricmp)
+    __stricmp;
+
+    MACRO_FUNCTION_RESOLVER(
+        int(__cdecl*)(void* param_1), REIMPLEMENTED_CRT, Address::SHC_3BB0A8C1_0x0057FA62, &OpenSHC::OS::_atexit)
+    _atexit;
+
+    MACRO_FUNCTION_RESOLVER(
+        void(__cdecl*)(void* _Memory), REIMPLEMENTED_CRT, Address::SHC_3BB0A8C1_0x0057FA74, &OpenSHC::OS::_free)
+    _free;
+
+    MACRO_FUNCTION_RESOLVER(
+        int(__cdecl*)(int _C), REIMPLEMENTED_CRT, Address::SHC_3BB0A8C1_0x0057FC19, &OpenSHC::OS::_tolower)
+    _tolower;
+
+    MACRO_FUNCTION_RESOLVER(
+        int(__cdecl*)(FILE* _File), REIMPLEMENTED_CRT, Address::SHC_3BB0A8C1_0x0057FCB2, &OpenSHC::OS::_fclose)
+    _fclose;
+
+    MACRO_FUNCTION_RESOLVER(void(__cdecl*)(void* dstBuffer, size_t elSize, size_t count, FILE* file), REIMPLEMENTED_CRT,
+        Address::SHC_3BB0A8C1_0x0057FFCA, &OpenSHC::OS::_fread)
+    _fread;
+
+    MACRO_FUNCTION_RESOLVER(
+        void*(__cdecl*)(size_t _Size), REIMPLEMENTED_CRT, Address::SHC_3BB0A8C1_0x00580034, &OpenSHC::OS::_malloc)
+    _malloc;
+
+    MACRO_FUNCTION_RESOLVER(
+        long(__cdecl*)(FILE* _File), REIMPLEMENTED_CRT, Address::SHC_3BB0A8C1_0x0058028F, &OpenSHC::OS::_ftell)
+    _ftell;
+
+    MACRO_FUNCTION_RESOLVER(int(__cdecl*)(FILE* _File, long _Offset, FilePtrMoveMethodInt _Origin), REIMPLEMENTED_CRT,
+        Address::SHC_3BB0A8C1_0x00580384, &OpenSHC::OS::_fseek)
+    _fseek;
+
+    MACRO_FUNCTION_RESOLVER(FILE*(__cdecl*)(char* _Filename, char* _Mode), REIMPLEMENTED_CRT,
+        Address::SHC_3BB0A8C1_0x005804CD, &OpenSHC::OS::_fopen)
+    _fopen;
+
+    MACRO_FUNCTION_RESOLVER(int(__cdecl*)(wchar_t* _Dest, wchar_t* _Format, va_list _Args), REIMPLEMENTED_CRT,
+        Address::SHC_3BB0A8C1_0x00580577, &OpenSHC::OS::__vswprintf)
+    __vswprintf;
+
+    MACRO_FUNCTION_RESOLVER(
+        wint_t(__cdecl*)(FILE* _File), REIMPLEMENTED_CRT, Address::SHC_3BB0A8C1_0x00580735, &OpenSHC::OS::_fgetwc)
+    _fgetwc;
+
+    MACRO_FUNCTION_RESOLVER(size_t(__cdecl*)(void* _Str, size_t _Size, size_t _Count, FILE* _File), REIMPLEMENTED_CRT,
+        Address::SHC_3BB0A8C1_0x0058099B, &OpenSHC::OS::_fwrite)
+    _fwrite;
+
+    MACRO_FUNCTION_RESOLVER(wchar_t*(__cdecl*)(wchar_t * _Dest, wchar_t* _Source, size_t _Count), REIMPLEMENTED_CRT,
+        Address::SHC_3BB0A8C1_0x00580A1D, &OpenSHC::OS::_wcsncpy)
+    _wcsncpy;
+
+    MACRO_FUNCTION_RESOLVER(int(__cdecl*)(wchar_t* _Str1, wchar_t* _Str2), REIMPLEMENTED_CRT,
+        Address::SHC_3BB0A8C1_0x00580B69, &OpenSHC::OS::__wcsicmp)
+    __wcsicmp;
+
+    MACRO_FUNCTION_RESOLVER(
+        void(__cdecl*)(void* _Memory), REIMPLEMENTED_CRT, Address::SHC_3BB0A8C1_0x00580DC1, &OpenSHC::OS::_free)
+    _free;
+
+    MACRO_FUNCTION_RESOLVER(errno_t(__cdecl*)(void* _Dst, rsize_t _DstSize, void* _Src, rsize_t _MaxCount),
+        REIMPLEMENTED_CRT, Address::SHC_3BB0A8C1_0x00580DC6, &OpenSHC::OS::_memcpy_s)
+    _memcpy_s;
+
+    MACRO_FUNCTION_RESOLVER(
+        void(__cdecl*)(void* _Memory), REIMPLEMENTED_CRT, Address::SHC_3BB0A8C1_0x00580E9C, &OpenSHC::OS::_free)
+    _free;
+
+    MACRO_FUNCTION_RESOLVER(int(__cdecl*)(int fileDescriptor), REIMPLEMENTED_CRT, Address::SHC_3BB0A8C1_0x00580F38,
+        &OpenSHC::OS::_ucrt_close)
+    _ucrt_close;
+
+    MACRO_FUNCTION_RESOLVER(int(__cdecl*)(int fileDescriptor, void* destination, size_t size), REIMPLEMENTED_CRT,
+        Address::SHC_3BB0A8C1_0x005815C6, &OpenSHC::OS::_ucrt_read)
+    _ucrt_read;
+
+    MACRO_FUNCTION_RESOLVER(int(__cdecl*)(char* _Filename, OpenFlagInt _OpenFlag, int _PMode), REIMPLEMENTED_CRT,
+        Address::SHC_3BB0A8C1_0x005816C3, &OpenSHC::OS::_ucrt_open)
+    _ucrt_open;
+
+    MACRO_FUNCTION_RESOLVER(int(__cdecl*)(), REIMPLEMENTED_CRT, Address::SHC_3BB0A8C1_0x005816FB, &OpenSHC::OS::_rand)
+    _rand;
+
+    MACRO_FUNCTION_RESOLVER(
+        char*(__cdecl*)(char* string), REIMPLEMENTED_CRT, Address::SHC_3BB0A8C1_0x005818EB, &OpenSHC::OS::__strlwr)
+    __strlwr;
+
+    MACRO_FUNCTION_RESOLVER(undefined4(__cdecl*)(int fileDescriptor, void* src, uint size), REIMPLEMENTED_CRT,
+        Address::SHC_3BB0A8C1_0x00581F6F, &OpenSHC::OS::_ucrt_write)
+    _ucrt_write;
+
+    MACRO_FUNCTION_RESOLVER(void*(__cdecl*)(void* _Dst, void* _Src, size_t _Size), REIMPLEMENTED_CRT,
+        Address::SHC_3BB0A8C1_0x00582050, &OpenSHC::OS::_memcpy)
+    _memcpy;
+
+    MACRO_FUNCTION_RESOLVER(
+        int(__cdecl*)(int _C), REIMPLEMENTED_CRT, Address::SHC_3BB0A8C1_0x005824CD, &OpenSHC::OS::_toupper)
+    _toupper;
+
+    MACRO_FUNCTION_RESOLVER(int(__cdecl*)(int fileDescriptor, long lDistanceToMove, FilePtrMoveMethodInt moveMethod),
+        REIMPLEMENTED_CRT, Address::SHC_3BB0A8C1_0x0058277E, &OpenSHC::OS::_ucrt_lseek)
+    _ucrt_lseek;
+
+    MACRO_FUNCTION_RESOLVER(longlong(__stdcall*)(long dividend_lowOrder, long dividend_highOrder, long divisor_lowOrder,
+                                long divisor_highOrder),
+        REIMPLEMENTED_CRT, Address::SHC_3BB0A8C1_0x00582C30, &OpenSHC::OS::__alldiv)
+    __alldiv;
+
+    MACRO_FUNCTION_RESOLVER(ulonglong(__stdcall*)(ulong factor1_lowOrder, ulong factor1_highOrder,
+                                ulong factor2_lowOrder, ulong factor2_highOrder),
+        REIMPLEMENTED_CRT, Address::SHC_3BB0A8C1_0x00582CE0, &OpenSHC::OS::__allmul)
+    __allmul;
+
+    MACRO_FUNCTION_RESOLVER(
+        undefined4(__stdcall*)(), REIMPLEMENTED_CRT, Address::SHC_3BB0A8C1_0x005834A0, &OpenSHC::OS::__alloca_probe)
+    __alloca_probe;
+
+    MACRO_FUNCTION_RESOLVER(int(__cdecl*)(char* _Str1, char* _Str2, size_t _MaxCount), REIMPLEMENTED_CRT,
+        Address::SHC_3BB0A8C1_0x005835BB, &OpenSHC::OS::__strnicmp)
+    __strnicmp;
+
+    MACRO_FUNCTION_RESOLVER(
+        void(__cdecl*)(int _Code), REIMPLEMENTED_CRT, Address::SHC_3BB0A8C1_0x00583D55, &OpenSHC::OS::_exit)
+    _exit;
+
+    MACRO_FUNCTION_RESOLVER(uint(__cdecl*)(undefined4 param_1, uint param_2), REIMPLEMENTED_CRT,
+        Address::SHC_3BB0A8C1_0x00588628, &OpenSHC::OS::math_FUN_00588628)
+    math_FUN_00588628;
+
+    MACRO_FUNCTION_RESOLVER(float10(__fastcall*)(float10 param_1, char* param_2, int param_3, undefined4 param_4,
+                                undefined4 param_5, undefined4 param_6, undefined4 param_7),
+        REIMPLEMENTED_CRT, Address::SHC_3BB0A8C1_0x0058864B, &OpenSHC::OS::math_FUN_0058864b)
+    math_FUN_0058864b;
+
+    MACRO_FUNCTION_RESOLVER(
+        float10(__fastcall*)(), REIMPLEMENTED_CRT, Address::SHC_3BB0A8C1_0x005887AE, &OpenSHC::OS::math_FUN_005887ae)
+    math_FUN_005887ae;
+
+} // namespace OS_Func
+} // namespace OpenSHC

--- a/src/OpenSHC/OS.hpp
+++ b/src/OpenSHC/OS.hpp
@@ -1,0 +1,132 @@
+/**
+  THIS FILE IS AUTO GENERATED
+  Communicate changes to the dev team (e.g. via a Pull Request).
+  Changes get lost otherwise.
+
+  path: 'OpenSHC/OS.hpp'
+*/
+
+#pragma once
+
+#include "OpenSHC/WindowsHelper/Enums/BOOLEnum.hpp"
+#include "OpenSHC/WindowsHelper/Enums/FilePtrMoveMethodInt.hpp"
+#include "OpenSHC/WindowsHelper/Enums/OpenFlagInt.hpp"
+#include "crtdefs.h"
+#include "guiddef.h"
+#include "mbstring.h"
+#include "time.h"
+#include "vadefs.h"
+namespace OpenSHC {
+namespace OS {
+
+    using OpenSHC::WindowsHelper::Enums::BOOLEnum;
+    using OpenSHC::WindowsHelper::Enums::FilePtrMoveMethodInt;
+    using OpenSHC::WindowsHelper::Enums::OpenFlagInt;
+
+    int* __stdcall basic_ofstream_write(void* param_1, uint param_2);
+
+    BOOLEnum __cdecl isEqualGUID(GUID* param_1, GUID* param_2);
+
+    int __cdecl __isnan(double _X);
+
+    int __cdecl __ftol2(float10 param);
+
+    void __cdecl math_atan_FUN_0057ee10(float10 param_1);
+
+    float10 __cdecl math_atan_FUN_0057ee68(float10 floatIn, uint eaxIn, int param_3, int param_4);
+
+    float10 __cdecl math_sqrt_FUN_0057eef0(float10 param_1);
+
+    float10 __cdecl math_sqrt_FUN_0057ef0d(int param_1, uint param_2, float10 param_3);
+
+    void __cdecl math_tan_1_FUN_0057eff0(float10 param_1);
+
+    float10 __cdecl math_FUN_0057f048(int param_1, int param_2);
+
+    float10 __fastcall math_cos(float10 param_1);
+
+    float10 __fastcall math_sin(float10 param_1);
+
+    tm* __cdecl __localtime64(__time32_t* _Time);
+
+    __time64_t __cdecl __time64(__time64_t* _Time);
+
+    void* __cdecl _memset(void* _Dst, int _Val, size_t _Size);
+
+    int __cdecl _sprintf(char* _Dest, char* _Format);
+
+    int __cdecl __stricmp(char* _Str1, char* _Str2);
+
+    int __cdecl _atexit(void* param_1);
+
+    void __cdecl _free(void* _Memory);
+
+    int __cdecl _tolower(int _C);
+
+    int __cdecl _fclose(FILE* _File);
+
+    void __cdecl _fread(void* dstBuffer, size_t elSize, size_t count, FILE* file);
+
+    void* __cdecl _malloc(size_t _Size);
+
+    long __cdecl _ftell(FILE* _File);
+
+    int __cdecl _fseek(FILE* _File, long _Offset, FilePtrMoveMethodInt _Origin);
+
+    FILE* __cdecl _fopen(char* _Filename, char* _Mode);
+
+    int __cdecl __vswprintf(wchar_t* _Dest, wchar_t* _Format, va_list _Args);
+
+    wint_t __cdecl _fgetwc(FILE* _File);
+
+    size_t __cdecl _fwrite(void* _Str, size_t _Size, size_t _Count, FILE* _File);
+
+    wchar_t* __cdecl _wcsncpy(wchar_t* _Dest, wchar_t* _Source, size_t _Count);
+
+    int __cdecl __wcsicmp(wchar_t* _Str1, wchar_t* _Str2);
+
+    void __cdecl _free(void* _Memory);
+
+    errno_t __cdecl _memcpy_s(void* _Dst, rsize_t _DstSize, void* _Src, rsize_t _MaxCount);
+
+    void __cdecl _free(void* _Memory);
+
+    int __cdecl _ucrt_close(int fileDescriptor);
+
+    int __cdecl _ucrt_read(int fileDescriptor, void* destination, size_t size);
+
+    int __cdecl _ucrt_open(char* _Filename, OpenFlagInt _OpenFlag, int _PMode);
+
+    int __cdecl _rand();
+
+    char* __cdecl __strlwr(char* string);
+
+    undefined4 __cdecl _ucrt_write(int fileDescriptor, void* src, uint size);
+
+    void* __cdecl _memcpy(void* _Dst, void* _Src, size_t _Size);
+
+    int __cdecl _toupper(int _C);
+
+    int __cdecl _ucrt_lseek(int fileDescriptor, long lDistanceToMove, FilePtrMoveMethodInt moveMethod);
+
+    longlong __stdcall __alldiv(
+        long dividend_lowOrder, long dividend_highOrder, long divisor_lowOrder, long divisor_highOrder);
+
+    ulonglong __stdcall __allmul(
+        ulong factor1_lowOrder, ulong factor1_highOrder, ulong factor2_lowOrder, ulong factor2_highOrder);
+
+    undefined4 __stdcall __alloca_probe();
+
+    int __cdecl __strnicmp(char* _Str1, char* _Str2, size_t _MaxCount);
+
+    void __cdecl _exit(int _Code);
+
+    uint __cdecl math_FUN_00588628(undefined4 param_1, uint param_2);
+
+    float10 __fastcall math_FUN_0058864b(float10 param_1, char* param_2, int param_3, undefined4 param_4,
+        undefined4 param_5, undefined4 param_6, undefined4 param_7);
+
+    float10 __fastcall math_FUN_005887ae();
+
+} // namespace OS
+} // namespace OpenSHC

--- a/src/precomp/addresses-SHC-3BB0A8C1.hpp
+++ b/src/precomp/addresses-SHC-3BB0A8C1.hpp
@@ -24712,7 +24712,7 @@ enum {
     // type: function
     SHC_3BB0A8C1_0x00479140 = 0x00479140,
     // label: basic_ofstream_write
-    // location: HoldStrong_lib
+    // location: OpenSHC/OS
     // type: function
     SHC_3BB0A8C1_0x004791B0 = 0x004791B0,
     // type: function
@@ -24956,7 +24956,7 @@ enum {
     // label: FID_conflict:IsEqualGUID
     // label: isEqualGUID
     // location:
-    // location: HoldStrong_lib
+    // location: OpenSHC/OS
     // type: function
     SHC_3BB0A8C1_0x0047C5D0 = 0x0047C5D0,
     // label: MenuItemRenderFunction_NetworkSessions_Buttons
@@ -72101,11 +72101,11 @@ enum {
     // location: HoldStrong_lib
     // type: function
     SHC_3BB0A8C1_0x0057C85F = 0x0057C85F,
-    // label: SetWindowLongAThunk
+    // label: SetWindowLongA_user32_Thunk
     // location: HoldStrong_lib
     // type: function
     SHC_3BB0A8C1_0x0057C884 = 0x0057C884,
-    // label: GetShortPathNameW_Thunk
+    // label: GetShortPathNameW_kernel32_Thunk
     // location: HoldStrong_lib
     // type: function
     SHC_3BB0A8C1_0x0057C8A9 = 0x0057C8A9,
@@ -72572,35 +72572,35 @@ enum {
     // type: function
     SHC_3BB0A8C1_0x0057ECD3 = 0x0057ECD3,
     // label: __isnan
-    // location: HoldStrong_lib
+    // location: OpenSHC/OS
     // type: function
     SHC_3BB0A8C1_0x0057ECF1 = 0x0057ECF1,
-    // label: DoubleOrFloat10ToIntUnk
-    // location: HoldStrong_lib
+    // label: __ftol2
+    // location: OpenSHC/OS
     // type: function
     SHC_3BB0A8C1_0x0057ED20 = 0x0057ED20,
     // type: function
     SHC_3BB0A8C1_0x0057ED56 = 0x0057ED56,
     // label: math_atan_FUN_0057ee10
-    // location: HoldStrong_lib
+    // location: OpenSHC/OS
     // type: function
     SHC_3BB0A8C1_0x0057EE10 = 0x0057EE10,
     // label: math_atan_FUN_0057ee68
-    // location: HoldStrong_lib
+    // location: OpenSHC/OS
     // type: function
     SHC_3BB0A8C1_0x0057EE68 = 0x0057EE68,
     // type: function
     SHC_3BB0A8C1_0x0057EECB = 0x0057EECB,
     // label: math_sqrt_FUN_0057eef0
-    // location: HoldStrong_lib
+    // location: OpenSHC/OS
     // type: function
     SHC_3BB0A8C1_0x0057EEF0 = 0x0057EEF0,
     // label: math_sqrt_FUN_0057ef0d
-    // location: HoldStrong_lib
+    // location: OpenSHC/OS
     // type: function
     SHC_3BB0A8C1_0x0057EF0D = 0x0057EF0D,
     // label: math_tan_1_FUN_0057eff0
-    // location: HoldStrong_lib
+    // location: OpenSHC/OS
     // type: function
     SHC_3BB0A8C1_0x0057EFF0 = 0x0057EFF0,
     // label: FUN_0057f03f
@@ -72608,11 +72608,11 @@ enum {
     // type: function
     SHC_3BB0A8C1_0x0057F03F = 0x0057F03F,
     // label: math_FUN_0057f048
-    // location: HoldStrong_lib
+    // location: OpenSHC/OS
     // type: function
     SHC_3BB0A8C1_0x0057F048 = 0x0057F048,
     // label: math_cos
-    // location: HoldStrong_lib
+    // location: OpenSHC/OS
     // type: function
     SHC_3BB0A8C1_0x0057F120 = 0x0057F120,
     // label: FUN_0057f16f
@@ -72624,7 +72624,7 @@ enum {
     // type: function
     SHC_3BB0A8C1_0x0057F178 = 0x0057F178,
     // label: math_sin
-    // location: HoldStrong_lib
+    // location: OpenSHC/OS
     // type: function
     SHC_3BB0A8C1_0x0057F250 = 0x0057F250,
     // type: function
@@ -72640,21 +72640,21 @@ enum {
     // label: FID_conflict:__gmtime32
     // label: FID_conflict:__gmtime64
     // label: FID_conflict:__localtime32
-    // label: FID_conflict:__localtime64
+    // label: __localtime64
     // location:
-    // location: HoldStrong_lib
+    // location: OpenSHC/OS
     // type: function
     SHC_3BB0A8C1_0x0057F5FE = 0x0057F5FE,
     // label: __time64
-    // location: HoldStrong_lib
+    // location: OpenSHC/OS
     // type: function
     SHC_3BB0A8C1_0x0057F622 = 0x0057F622,
     // label: _memset
-    // location: HoldStrong_lib
+    // location: OpenSHC/OS
     // type: function
     SHC_3BB0A8C1_0x0057F660 = 0x0057F660,
     // label: _sprintf
-    // location: HoldStrong_lib
+    // location: OpenSHC/OS
     // type: function
     SHC_3BB0A8C1_0x0057F6DA = 0x0057F6DA,
     // label: __security_check_cookie
@@ -72676,7 +72676,7 @@ enum {
     // type: function
     SHC_3BB0A8C1_0x0057F81B = 0x0057F81B,
     // label: __stricmp
-    // location: HoldStrong_lib
+    // location: OpenSHC/OS
     // type: function
     SHC_3BB0A8C1_0x0057F8EE = 0x0057F8EE,
     // label: FUN_0057f93e
@@ -72696,11 +72696,11 @@ enum {
     // type: function
     SHC_3BB0A8C1_0x0057FA5C = 0x0057FA5C,
     // label: _atexit
-    // location: HoldStrong_lib
+    // location: OpenSHC/OS
     // type: function
     SHC_3BB0A8C1_0x0057FA62 = 0x0057FA62,
     // label: _free
-    // location: HoldStrong_lib
+    // location: OpenSHC/OS
     // type: function
     SHC_3BB0A8C1_0x0057FA74 = 0x0057FA74,
     // label: FUN_0057faca
@@ -72714,7 +72714,7 @@ enum {
     // type: function
     SHC_3BB0A8C1_0x0057FB02 = 0x0057FB02,
     // label: _tolower
-    // location: HoldStrong_lib
+    // location: OpenSHC/OS
     // type: function
     SHC_3BB0A8C1_0x0057FC19 = 0x0057FC19,
     // label: FUN_0057fc40
@@ -72722,7 +72722,7 @@ enum {
     // type: function
     SHC_3BB0A8C1_0x0057FC40 = 0x0057FC40,
     // label: _fclose
-    // location: HoldStrong_lib
+    // location: OpenSHC/OS
     // type: function
     SHC_3BB0A8C1_0x0057FCB2 = 0x0057FCB2,
     // label: FUN_0057fd26
@@ -72742,7 +72742,7 @@ enum {
     // type: function
     SHC_3BB0A8C1_0x0057FFC0 = 0x0057FFC0,
     // label: _fread
-    // location: HoldStrong_lib
+    // location: OpenSHC/OS
     // type: function
     SHC_3BB0A8C1_0x0057FFCA = 0x0057FFCA,
     // label: _V6_HeapAlloc
@@ -72754,7 +72754,7 @@ enum {
     // type: function
     SHC_3BB0A8C1_0x0058002B = 0x0058002B,
     // label: _malloc
-    // location: HoldStrong_lib
+    // location: OpenSHC/OS
     // type: function
     SHC_3BB0A8C1_0x00580034 = 0x00580034,
     // label: FUN_005800f7
@@ -72762,7 +72762,7 @@ enum {
     // type: function
     SHC_3BB0A8C1_0x005800F7 = 0x005800F7,
     // label: _ftell
-    // location: HoldStrong_lib
+    // location: OpenSHC/OS
     // type: function
     SHC_3BB0A8C1_0x0058028F = 0x0058028F,
     // label: FUN_005802f3
@@ -72774,7 +72774,7 @@ enum {
     // type: function
     SHC_3BB0A8C1_0x005802FD = 0x005802FD,
     // label: _fseek
-    // location: HoldStrong_lib
+    // location: OpenSHC/OS
     // type: function
     SHC_3BB0A8C1_0x00580384 = 0x00580384,
     // label: FUN_005803ff
@@ -72790,7 +72790,7 @@ enum {
     // type: function
     SHC_3BB0A8C1_0x005804C3 = 0x005804C3,
     // label: _fopen
-    // location: HoldStrong_lib
+    // location: OpenSHC/OS
     // type: function
     SHC_3BB0A8C1_0x005804CD = 0x005804CD,
     // label: __vswprintf_l
@@ -72798,7 +72798,7 @@ enum {
     // type: function
     SHC_3BB0A8C1_0x005804E0 = 0x005804E0,
     // label: __vswprintf
-    // location: HoldStrong_lib
+    // location: OpenSHC/OS
     // type: function
     SHC_3BB0A8C1_0x00580577 = 0x00580577,
     // label: FUN_0058058e
@@ -72806,7 +72806,7 @@ enum {
     // type: function
     SHC_3BB0A8C1_0x0058058E = 0x0058058E,
     // label: _fgetwc
-    // location: HoldStrong_lib
+    // location: OpenSHC/OS
     // type: function
     SHC_3BB0A8C1_0x00580735 = 0x00580735,
     // label: FUN_0058079e
@@ -72826,7 +72826,7 @@ enum {
     // type: function
     SHC_3BB0A8C1_0x0058083C = 0x0058083C,
     // label: _fwrite
-    // location: HoldStrong_lib
+    // location: OpenSHC/OS
     // type: function
     SHC_3BB0A8C1_0x0058099B = 0x0058099B,
     // label: FUN_00580a13
@@ -72834,7 +72834,7 @@ enum {
     // type: function
     SHC_3BB0A8C1_0x00580A13 = 0x00580A13,
     // label: _wcsncpy
-    // location: HoldStrong_lib
+    // location: OpenSHC/OS
     // type: function
     SHC_3BB0A8C1_0x00580A1D = 0x00580A1D,
     // label: __wcsicmp_l
@@ -72842,7 +72842,7 @@ enum {
     // type: function
     SHC_3BB0A8C1_0x00580A5A = 0x00580A5A,
     // label: __wcsicmp
-    // location: HoldStrong_lib
+    // location: OpenSHC/OS
     // type: function
     SHC_3BB0A8C1_0x00580B69 = 0x00580B69,
     // label: WCharStringToLong
@@ -72922,11 +72922,11 @@ enum {
     // type: function
     SHC_3BB0A8C1_0x00580DA6 = 0x00580DA6,
     // label: _free
-    // location: HoldStrong_lib
+    // location: OpenSHC/OS
     // type: function
     SHC_3BB0A8C1_0x00580DC1 = 0x00580DC1,
     // label: _memcpy_s
-    // location: HoldStrong_lib
+    // location: OpenSHC/OS
     // type: function
     SHC_3BB0A8C1_0x00580DC6 = 0x00580DC6,
     // label: _memmove_s
@@ -72934,7 +72934,7 @@ enum {
     // type: function
     SHC_3BB0A8C1_0x00580E41 = 0x00580E41,
     // label: _free
-    // location: HoldStrong_lib
+    // location: OpenSHC/OS
     // type: function
     SHC_3BB0A8C1_0x00580E9C = 0x00580E9C,
     // label: FUN_00580ea1
@@ -72942,7 +72942,7 @@ enum {
     // type: function
     SHC_3BB0A8C1_0x00580EA1 = 0x00580EA1,
     // label: _ucrt_close
-    // location: HoldStrong_lib
+    // location: OpenSHC/OS
     // type: function
     SHC_3BB0A8C1_0x00580F38 = 0x00580F38,
     // label: FUN_00580ffb
@@ -72957,17 +72957,17 @@ enum {
     // location: HoldStrong_lib/FUN_00581005/override
     SHC_3BB0A8C1_0x005813FC = 0x005813FC,
     // label: _ucrt_read
-    // location: HoldStrong_lib
+    // location: OpenSHC/OS
     // type: function
     SHC_3BB0A8C1_0x005815C6 = 0x005815C6,
     // label: FUN_005816b9
     // location: HoldStrong_lib
     // type: function
     SHC_3BB0A8C1_0x005816B9 = 0x005816B9,
-    // label: FID_conflict:_open
     // label: FID_conflict:open
+    // label: _ucrt_open
     // location:
-    // location: HoldStrong_lib
+    // location: OpenSHC/OS
     // type: function
     SHC_3BB0A8C1_0x005816C3 = 0x005816C3,
     // label: SetRNGSeed
@@ -72975,7 +72975,7 @@ enum {
     // type: function
     SHC_3BB0A8C1_0x005816EE = 0x005816EE,
     // label: _rand
-    // location: HoldStrong_lib
+    // location: OpenSHC/OS
     // type: function
     SHC_3BB0A8C1_0x005816FB = 0x005816FB,
     // label: __freea
@@ -72992,8 +72992,8 @@ enum {
     // location: HoldStrong_lib
     // type: function
     SHC_3BB0A8C1_0x005818B9 = 0x005818B9,
-    // label: StringToLowerCase
-    // location: OpenSHC/Global
+    // label: __strlwr
+    // location: OpenSHC/OS
     // type: function
     SHC_3BB0A8C1_0x005818EB = 0x005818EB,
     // label: FUN_0058194d
@@ -73001,7 +73001,7 @@ enum {
     // type: function
     SHC_3BB0A8C1_0x0058194D = 0x0058194D,
     // label: _ucrt_write
-    // location: HoldStrong_lib
+    // location: OpenSHC/OS
     // type: function
     SHC_3BB0A8C1_0x00581F6F = 0x00581F6F,
     // label: FUN_00582041
@@ -73009,7 +73009,7 @@ enum {
     // type: function
     SHC_3BB0A8C1_0x00582041 = 0x00582041,
     // label: _memcpy
-    // location: HoldStrong_lib
+    // location: OpenSHC/OS
     // type: function
     SHC_3BB0A8C1_0x00582050 = 0x00582050,
     // type: function
@@ -73115,7 +73115,7 @@ enum {
     // type: function
     SHC_3BB0A8C1_0x005823B5 = 0x005823B5,
     // label: _toupper
-    // location: HoldStrong_lib
+    // location: OpenSHC/OS
     // type: function
     SHC_3BB0A8C1_0x005824CD = 0x005824CD,
     // label: FUN_005824f4
@@ -73159,7 +73159,7 @@ enum {
     // type: function
     SHC_3BB0A8C1_0x0058270C = 0x0058270C,
     // label: _ucrt_lseek
-    // location: HoldStrong_lib
+    // location: OpenSHC/OS
     // type: function
     SHC_3BB0A8C1_0x0058277E = 0x0058277E,
     // label: Unlock
@@ -73236,11 +73236,11 @@ enum {
     // type: function
     SHC_3BB0A8C1_0x00582BC3 = 0x00582BC3,
     // label: __alldiv
-    // location: HoldStrong_lib
+    // location: OpenSHC/OS
     // type: function
     SHC_3BB0A8C1_0x00582C30 = 0x00582C30,
     // label: __allmul
-    // location: HoldStrong_lib
+    // location: OpenSHC/OS
     // type: function
     SHC_3BB0A8C1_0x00582CE0 = 0x00582CE0,
     // label: FUN_00582d14
@@ -73324,7 +73324,7 @@ enum {
     // label: __alloca_probe
     // label: __chkstk
     // location:
-    // location: HoldStrong_lib
+    // location: OpenSHC/OS
     // type: function
     SHC_3BB0A8C1_0x005834A0 = 0x005834A0,
     // label: __strnicmp_l
@@ -73332,7 +73332,7 @@ enum {
     // type: function
     SHC_3BB0A8C1_0x005834CB = 0x005834CB,
     // label: __strnicmp
-    // location: HoldStrong_lib
+    // location: OpenSHC/OS
     // type: function
     SHC_3BB0A8C1_0x005835BB = 0x005835BB,
     // label: _atol
@@ -73486,7 +73486,7 @@ enum {
     // type: function
     SHC_3BB0A8C1_0x00583D4F = 0x00583D4F,
     // label: _exit
-    // location: HoldStrong_lib
+    // location: OpenSHC/OS
     // type: function
     SHC_3BB0A8C1_0x00583D55 = 0x00583D55,
     // label: __exit
@@ -73978,13 +73978,13 @@ enum {
     // type: function
     SHC_3BB0A8C1_0x005885E5 = 0x005885E5,
     // label: math_FUN_00588628
-    // location: HoldStrong_lib
+    // location: OpenSHC/OS
     // type: function
     SHC_3BB0A8C1_0x00588628 = 0x00588628,
     // type: function
     SHC_3BB0A8C1_0x0058863E = 0x0058863E,
     // label: math_FUN_0058864b
-    // location: HoldStrong_lib
+    // location: OpenSHC/OS
     // type: function
     SHC_3BB0A8C1_0x0058864B = 0x0058864B,
     // label: __startOneArgErrorHandling
@@ -73996,7 +73996,7 @@ enum {
     // type: function
     SHC_3BB0A8C1_0x00588790 = 0x00588790,
     // label: math_FUN_005887ae
-    // location: HoldStrong_lib
+    // location: OpenSHC/OS
     // type: function
     SHC_3BB0A8C1_0x005887AE = 0x005887AE,
     // label: FUN_005889f0
@@ -75462,7 +75462,7 @@ enum {
     // location: HoldStrong_lib
     // type: function
     SHC_3BB0A8C1_0x0059987C = 0x0059987C,
-    // label: GetStringTypeWThunk
+    // label: GetStringTypeW_kernel32_Thunk
     // location: HoldStrong_lib
     // type: function
     SHC_3BB0A8C1_0x005998A1 = 0x005998A1,
@@ -75622,7 +75622,7 @@ enum {
     // location: HoldStrong_lib
     // type: function
     SHC_3BB0A8C1_0x00599C08 = 0x00599C08,
-    // label: SomeCxxFrameHandlerUnk
+    // label: CxxFrameHandlerThunk_00599c10
     // location: HoldStrong_lib
     // type: function
     SHC_3BB0A8C1_0x00599C10 = 0x00599C10,
@@ -97653,6 +97653,8 @@ enum {
     SHC_3BB0A8C1_0x0242921C = 0x0242921C,
     // type: /undefined4
     SHC_3BB0A8C1_0x02429220 = 0x02429220,
+    // label: LIB_g_HasSSE2
+    // location:
     // type: /int
     SHC_3BB0A8C1_0x02429224 = 0x02429224,
     // label: DAT_CommandLine


### PR DESCRIPTION
Moved os-specific functions that the game uses to OpenSHC/OS instead of leaving them out of the repo. This allows us to get 100% match and avoid crashes due to mixing statically linked CRT in the original exe and in the OpenSHC dll.

`REIMPLEMENTED_CRT` is set to 0 in CMakeLists.txt for the OpenSHC dll target. This should be set to 1 if all OS functions are reimplemented (or stubbed) and testing is required.

We can either use `// STUB` or `// FUNCTION` for any OS function depending on whether we want to ignore reimplementation accuracy of the static lib function (preferred), or whether we want to actually track reimplementation progress of the lib function (can be used if static lib functions turn out to be linker/compiler generated in a custom fashion for the original binary)