### PR TITLE
[PROJECT] Remove global func from dll entry avoiding compile step

### DIFF
--- a/src/entry.cpp
+++ b/src/entry.cpp
@@ -1,15 +1,15 @@
 
-#include "OpenSHC/Global.func.hpp"
+#ifdef OPEN_SHC_DLL
 
 #include "lua.h"
-
-#ifdef OPEN_SHC_DLL
 
 extern "C" __declspec(dllexport) int __cdecl luaopen_OpenSHC(lua_State* L) { return 0; }
 
 #endif
 
 #ifdef OPEN_SHC_EXE
+
+#include "OpenSHC/Global.func.hpp"
 
 int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, PSTR lpCmdLine, int nCmdShow)
 {


### PR DESCRIPTION
`entry.cpp` always pulled in the gobal function resolvers. These file is big and while it will one day be needed, it has no effect here when reimplementing other functions.

Split the includes between dll and exe in the header.