### PR TITLE
[PROJECT] Add qualifier formatting

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -6,4 +6,7 @@ TabWidth: 4
 UseTab: Never
 InsertNewlineAtEOF: true
 SpaceInEmptyBraces: Never
+PointerAlignment: Left
+QualifierAlignment: Custom
+QualifierOrder: [inline, static, type, const, volatile]
 ...

--- a/src/core/Resolver.cpp
+++ b/src/core/Resolver.cpp
@@ -9,8 +9,8 @@
 
 static void createRelativeJump(int from, int to)
 {
-    const int instructionLength = 5;
-    const int relativeOffset = to - (from + instructionLength);
+    int const instructionLength = 5;
+    int const relativeOffset = to - (from + instructionLength);
 
     DWORD oldProtection;
     if (!VirtualProtect((void*)from, instructionLength, PAGE_EXECUTE_READWRITE, &oldProtection)) {
@@ -36,7 +36,7 @@ static void createRelativeJump(int from, int to)
 #endif
 
 void StructResolver::initialize(
-    bool& initialized, bool isImplemented, int gameAddress, const void* structPtr, const char* typeName)
+    bool& initialized, bool isImplemented, int gameAddress, void const* structPtr, char const* typeName)
 {
     if (initialized) {
 #ifdef OPEN_SHC_EXE
@@ -67,7 +67,7 @@ void StructResolver::initialize(
 }
 
 void FunctionResolver::initialize(
-    bool& initialized, bool isImplemented, int gameAddress, const void* funcPtr, const char* funcName)
+    bool& initialized, bool isImplemented, int gameAddress, void const* funcPtr, char const* funcName)
 {
     if (initialized) {
 #ifdef OPEN_SHC_EXE

--- a/src/precomp/FunctionResolver.h
+++ b/src/precomp/FunctionResolver.h
@@ -177,7 +177,7 @@ private:
     };
 
     static void initialize(
-        bool& initialized, bool isImplemented, int gameAddress, const void* funcPtr, const char* funcName);
+        bool& initialized, bool isImplemented, int gameAddress, void const* funcPtr, char const* funcName);
 
     template <int options> struct OptionFlags {
         enum {
@@ -198,18 +198,18 @@ public:
     struct Resolver {
     private:
         // only use this for internal logic and declarations/definitions
-        static const bool isImplemented = OPEN_SHC_IMPLEMENTED(implemented);
+        static bool const isImplemented = OPEN_SHC_IMPLEMENTED(implemented);
 
         typedef OptionFlags<options> Flags;
 
         struct Initializer {
             Initializer();
         };
-        static const Initializer initializer;
+        static Initializer const initializer;
 
         template <bool implemented, bool wrapper, typename _> struct FunctionPtrUnifier;
         template <typename _> struct FunctionPtrUnifier<true, false, _> {
-            inline static const FuncPtrType get() { return funcAddress; }
+            inline static FuncPtrType const get() { return funcAddress; }
         };
 
         // At the moment, there is not much sense in allowing the wrapper function for the exe.
@@ -218,10 +218,10 @@ public:
 #ifdef OPEN_SHC_DLL
 
         template <typename _> struct FunctionPtrUnifier<false, false, _> {
-            inline static const FuncPtrType get() { return GameFunction<FuncPtrType>::get(); }
+            inline static FuncPtrType const get() { return GameFunction<FuncPtrType>::get(); }
         };
         template <bool implemented, typename _> struct FunctionPtrUnifier<implemented, true, _> {
-            inline static const FuncPtrType get()
+            inline static FuncPtrType const get()
             {
                 return reinterpret_cast<FuncPtrType>(&Wrapper<FuncPtrType>::Function::call);
             }
@@ -418,14 +418,14 @@ public:
 template <int address> bool FunctionResolver::AddressUsageKeeper<address>::initialized = false;
 
 template <typename FuncPtrType, bool implemented, int gameAddress, FuncPtrType funcAddress, int options>
-const typename FunctionResolver::Resolver<FuncPtrType, implemented, gameAddress, funcAddress, options>::Initializer
+typename FunctionResolver::Resolver<FuncPtrType, implemented, gameAddress, funcAddress, options>::Initializer const
     FunctionResolver::Resolver<FuncPtrType, implemented, gameAddress, funcAddress, options>::initializer;
 
 template <typename FuncPtrType, bool implemented, int gameAddress, FuncPtrType funcAddress, int options>
 FunctionResolver::Resolver<FuncPtrType, implemented, gameAddress, funcAddress, options>::Initializer::Initializer()
 {
-    const FuncPtrType funcPtr = Function::get();
-    const void* func = *((void**)&funcPtr);
+    FuncPtrType const funcPtr = Function::get();
+    void const* func = *((void**)&funcPtr);
     initialize(AddressUsageKeeper<gameAddress>::initialized, isImplemented, gameAddress, func,
         getFuncPtrName<FuncPtrType, funcAddress>());
 }

--- a/src/precomp/StructResolver.h
+++ b/src/precomp/StructResolver.h
@@ -20,18 +20,18 @@ private:
     };
 
     static void initialize(
-        bool& initialized, bool isImplemented, int gameAddress, const void* structPtr, const char* typeName);
+        bool& initialized, bool isImplemented, int gameAddress, void const* structPtr, char const* typeName);
 
 public:
     template <typename T, bool implemented, int gameAddress> struct Resolver {
     private:
         // only use this for internal logic and declarations/definitions
-        static const bool isImplemented = OPEN_SHC_IMPLEMENTED(implemented);
+        static bool const isImplemented = OPEN_SHC_IMPLEMENTED(implemented);
 
         struct Initializer {
             Initializer();
         };
-        static const Initializer initializer;
+        static Initializer const initializer;
 
     public:
         typedef typename InternalResolver<T, isImplemented, gameAddress> Ptr;
@@ -48,7 +48,7 @@ T* const StructResolver::InternalResolver<T, true, gameAddress>::ptr
 template <int address> bool StructResolver::AddressUsageKeeper<address>::initialized = false;
 
 template <typename T, bool implemented, int gameAddress>
-const typename StructResolver::Resolver<T, implemented, gameAddress>::Initializer
+typename StructResolver::Resolver<T, implemented, gameAddress>::Initializer const
     StructResolver::Resolver<T, implemented, gameAddress>::initializer;
 
 template <typename T, bool implemented, int gameAddress>

--- a/src/precomp/TypeUtility.h
+++ b/src/precomp/TypeUtility.h
@@ -3,17 +3,17 @@
 
 #include <string>
 
-template <typename T> const char* getTypeName()
+template <typename T> char const* getTypeName()
 {
     static std::string cached;
     if (!cached.empty()) {
         return cached.c_str();
     }
-    static const char* fallback = "<UNKNOWN>";
+    static char const* fallback = "<UNKNOWN>";
 
-    const char* sig = __FUNCSIG__;
-    const char* start = std::strchr(sig, '<');
-    const char* end = std::strrchr(sig, '>');
+    char const* sig = __FUNCSIG__;
+    char const* start = std::strchr(sig, '<');
+    char const* end = std::strrchr(sig, '>');
 
     if (start && end && end > start) {
         cached = std::string(start + 1, end);
@@ -23,29 +23,29 @@ template <typename T> const char* getTypeName()
     return cached.c_str();
 }
 
-template <typename FuncPtrType, FuncPtrType funcPtr> const char* getFuncPtrName()
+template <typename FuncPtrType, FuncPtrType funcPtr> char const* getFuncPtrName()
 {
     static std::string cached;
     if (!cached.empty()) {
         return cached.c_str();
     }
-    static const char* fallback = "<UNKNOWN>";
+    static char const* fallback = "<UNKNOWN>";
 
-    const char* sig = __FUNCSIG__;
-    const char* typePart = getTypeName<FuncPtrType>();
+    char const* sig = __FUNCSIG__;
+    char const* typePart = getTypeName<FuncPtrType>();
     if (!typePart) {
         cached = fallback;
         return cached.c_str();
     }
 
-    const char* typeInThisSig = std::strstr(sig, typePart);
+    char const* typeInThisSig = std::strstr(sig, typePart);
     if (!typeInThisSig) {
         cached = fallback;
         return cached.c_str();
     }
 
-    const char* start = typeInThisSig + std::strlen(typePart);
-    const char* end = std::strrchr(sig, '>');
+    char const* start = typeInThisSig + std::strlen(typePart);
+    char const* end = std::strrchr(sig, '>');
     if (start && end && end > start) {
         cached = std::string(start + 1, end); // 1 for comma
     } else {


### PR DESCRIPTION
Also formatted `core` and `precomp` parts.
Note, that the clang-format options for this are considered a "risk", since they do not have the full type context.
In a quick test, at least the function resolver still worked. We will see. If issues arise, I at least know where to look.