### PR TITLE
reimplement: SHC_3BB0A8C1_0x0047A130 100%

### DIFF
--- a/src/OpenSHC/Audio/mss/SoundSystem/mapLoadingAndLaunchGameRelated1.cpp
+++ b/src/OpenSHC/Audio/mss/SoundSystem/mapLoadingAndLaunchGameRelated1.cpp
@@ -23,9 +23,9 @@ namespace Audio {
             DAT_GameCore::ptr->battleLevel = 0;
             DAT_GameCore::ptr->battleLevel2 = 0;
             DAT_GameCore::ptr->field36_0x90 = 0;
-            DAT_TroopValueState::ptr->attackInfo.field_0x469d8 = 0;
-            DAT_TroopValueState::ptr->attackInfo.field_0x469e0 = 0;
-            DAT_TroopValueState::ptr->attackInfo.field128082_0x469dc = 0;
+            DAT_TroopValueState::ptr->attackInfo.field128078_0x469d8 = 0;
+            DAT_TroopValueState::ptr->attackInfo.field128080_0x469e0 = 0;
+            DAT_TroopValueState::ptr->attackInfo.field128079_0x469dc = 0;
             DAT_SoundEffectsHelperData1::ptr->field8_0x3c = 0;
         }
 

--- a/src/OpenSHC/Audio/mss/SoundSystem/mapLoadingAndLaunchGameRelated1.cpp
+++ b/src/OpenSHC/Audio/mss/SoundSystem/mapLoadingAndLaunchGameRelated1.cpp
@@ -1,0 +1,34 @@
+#include "../SoundSystem.func.hpp"
+
+#include "OpenSHC/Random/RNG.func.hpp"
+
+#include "OpenSHC/Globals/DAT_GameCore.hpp"
+#include "OpenSHC/Globals/DAT_SoundEffectsHelperData1.hpp"
+#include "OpenSHC/Globals/DAT_TroopValueState.hpp"
+#include "OpenSHC/Globals/SEC_RNG.hpp"
+
+namespace OpenSHC {
+namespace Audio {
+    namespace MSS {
+
+        // FUNCTION: STRONGHOLDCRUSADER 0x0047A130
+        void SoundSystem::mapLoadingAndLaunchGameRelated1()
+        {
+            DAT_SoundEffectsHelperData1::ptr->SEC_Section1079.field0_0x0 = 1;
+            DAT_SoundEffectsHelperData1::ptr->SEC_Section1079.field1_0x4 = SEC_RNG::ptr->currentNumber1 % 4;
+            MACRO_CALL_MEMBER(Random::RNG_Func::nextRandomNumber1, SEC_RNG::ptr)();
+            DAT_SoundEffectsHelperData1::ptr->SEC_Section1079.incrementorUpTo4 = SEC_RNG::ptr->currentNumber1 % 4 + 1;
+            DAT_GameCore::ptr->cowPoisonTrackerUnk = 0;
+            DAT_GameCore::ptr->someSoundMatchTime_1 = DAT_GameCore::ptr->mapTimeInTicks;
+            DAT_GameCore::ptr->battleLevel = 0;
+            DAT_GameCore::ptr->battleLevel2 = 0;
+            DAT_GameCore::ptr->field36_0x90 = 0;
+            DAT_TroopValueState::ptr->attackInfo.field_0x469d8 = 0;
+            DAT_TroopValueState::ptr->attackInfo.field_0x469e0 = 0;
+            DAT_TroopValueState::ptr->attackInfo.field128082_0x469dc = 0;
+            DAT_SoundEffectsHelperData1::ptr->field8_0x3c = 0;
+        }
+
+    }
+}
+}

--- a/status/addresses-SHC-3BB0A8C1.txt
+++ b/status/addresses-SHC-3BB0A8C1.txt
@@ -10894,7 +10894,7 @@ SHC_3BB0A8C1_0x00479E60 | 100.0% | Reimplemented
 SHC_3BB0A8C1_0x00479F30 | 100.0% | Reimplemented
 SHC_3BB0A8C1_0x00479FC0 | 100.0% | Reimplemented
 SHC_3BB0A8C1_0x0047A080 | 0.0% | Pending
-SHC_3BB0A8C1_0x0047A130 | 0.0% | Pending
+SHC_3BB0A8C1_0x0047A130 | 100.0% | Reimplemented, but requires all used structs to be active
 SHC_3BB0A8C1_0x0047A1B0 | 100.0% | Reimplemented
 SHC_3BB0A8C1_0x0047A220 | 0.0% | Pending
 SHC_3BB0A8C1_0x0047A290 | 100.0% | Reimplemented


### PR DESCRIPTION
Requires changes to `AttackInfo`: Two new field sizes set.

This one showed the shortcomings of the struct resolver:  
Unlike the function resolver, which seems to be pretty good at behaving like a normal function, the struct resolver deeply effects the way the compiler handles field accesses. It required activating almost all of them to see the opcodes being produced like in the original. There is a clear difference between having the global or just a reference, no matter how stable. We always have to keep this in mind while testing around.

Also:
- The `private` functions should be made public. Pragmatic reason: We can not judge visibility and we can not instantiate classes with constructor if they are private.
- I found two struct resolvers for SHC_3BB0A8C1_0x01A279C0: In the class definition and as global. Is this intentional?