### PR TITLE
[FUNCTION_WRAPPER] Add ostream overload approach

### DIFF
--- a/cmake/core-sources.txt
+++ b/cmake/core-sources.txt
@@ -1,1 +1,2 @@
 src/core/Resolver.cpp
+src/core/OStreamOverloads/OStreamOverloads.cpp

--- a/src/core/OStreamOverloads/OStreamOverloads.cpp
+++ b/src/core/OStreamOverloads/OStreamOverloads.cpp
@@ -1,0 +1,15 @@
+#ifdef OPEN_SHC_DLL
+
+#include "OStreamOverloadsSupport.cpp" // provides support implementations
+
+/*
+    Include overload implementations here:
+    - The overload needs to be defined in OStreamOverloads.hpp.
+    - Implementation files should use "same" include directory as the header but relative to OStreamOverloads.cpp.
+    - Files should contain: the overload, the include for the type and an include for "OStreamOverloadsSupport.hpp".
+    - Support functions, macros and ostream imports are provided by and should be added to OStreamOverloadsSupport.hpp
+      and implemented in OStreamOverloadsSupport.cpp.
+*/
+#include "./OpenSHC/Audio/mss/UnkSoundFlagsAndLoopCount.cpp"
+
+#endif // OPEN_SHC_DLL

--- a/src/core/OStreamOverloads/OStreamOverloadsSupport.cpp
+++ b/src/core/OStreamOverloads/OStreamOverloadsSupport.cpp
@@ -1,0 +1,6 @@
+#include "OStreamOverloadsSupport.hpp"
+
+std::ostream& printEnum(std::ostream& os, char const* const name, unsigned int const value)
+{
+    return os << name << "(" << value << ")";
+}

--- a/src/core/OStreamOverloads/OStreamOverloadsSupport.hpp
+++ b/src/core/OStreamOverloads/OStreamOverloadsSupport.hpp
@@ -1,0 +1,17 @@
+#pragma once
+
+#include <iomanip>
+#include <ostream>
+
+/*
+    Support for enum printing.
+    The macro can be used to add a case, assign, break to a switch, easier allowing to add more cases.
+    Always consider number overlaps. The linter might warn, though.
+*/
+
+#define MACRO_ENUM_CASE(variable, name)                                                                                \
+    case name:                                                                                                         \
+        variable = #name;                                                                                              \
+        break;
+
+std::ostream& printEnum(std::ostream& os, char const* const name, unsigned int const value);

--- a/src/core/OStreamOverloads/OpenSHC/Audio/mss/UnkSoundFlagsAndLoopCount.cpp
+++ b/src/core/OStreamOverloads/OpenSHC/Audio/mss/UnkSoundFlagsAndLoopCount.cpp
@@ -1,0 +1,17 @@
+#include "OpenSHC/Audio/mss/UnkSoundFlagsAndLoopCount.hpp"
+
+#include "core/OStreamOverloads/OStreamOverloadsSupport.hpp"
+
+namespace OpenSHC {
+namespace Audio {
+    namespace MSS {
+
+        std::ostream& operator<<(std::ostream& os, UnkSoundFlagsAndLoopCount const& value)
+        {
+            return os << "{loopCount=" << value.loopCount << ", flagsUnk=0x" << std::hex << std::setw(2)
+                      << std::setfill('0') << static_cast<int>(value.flagsUnk) << std::dec << "}";
+        }
+
+    }
+}
+}

--- a/src/precomp/FunctionResolver.h
+++ b/src/precomp/FunctionResolver.h
@@ -7,6 +7,7 @@
 // NOTE: Changed CDECL tp CCALL to avoid window macro issue
 // TODO: Maybe change naming convention to not run into these issues
 
+#include "OStreamOverloads.hpp"
 #include "TypeUtility.h"
 #include "ucp3.h"
 #include <ios>

--- a/src/precomp/OStreamOverloads.hpp
+++ b/src/precomp/OStreamOverloads.hpp
@@ -1,0 +1,12 @@
+#pragma once
+
+#include <iosfwd>
+
+namespace OpenSHC {
+namespace Audio {
+    namespace MSS {
+        struct UnkSoundFlagsAndLoopCount;
+        std::ostream& operator<<(std::ostream&, UnkSoundFlagsAndLoopCount const&);
+    }
+}
+}


### PR DESCRIPTION
Closes #28.

As draft first, since I went with a rather strange approach, I guess.
My thoughts were essentially:
- I want to add overloads, maybe even for enums one day.
- I want separate files.
- I do not want them to compile in case of EXE.

I went with the not recommended, unusual cpp-include, building basically one cpp file that I added to core.
So I went with the most complicated first.

I can backpaddle if I overdid it:
- We can leave out the mirror of the directory structure, assuming we will not have type name collisions.
- We can leave out the "cpp" include approach and instead work with adding an additional cpp to core for every overload, ignoring the filter for dll/exe (might be overkill anyway).
- We can go back to one file and only think about splitting again in case the file grows beyond 1000 or 2000 lines.

What do you think?

Being honest I was actually going with one file, but then I thought about the enums. But the enums as they are used in the function parameters are not enums currently, but aliased ints, etc, so as of now, there is nothing to gain by overloading enums anyway.
Unless we switch the int aliased enums in the function parameters to the actual enum type and only use the int version in case of structs...