### PR TITLE
[SoundSystem] adapt to sound system files type change

### DIFF
--- a/src/OpenSHC/Audio/mss/SoundSystem/deactivateSoundFromMenuFuncUnk.cpp
+++ b/src/OpenSHC/Audio/mss/SoundSystem/deactivateSoundFromMenuFuncUnk.cpp
@@ -1,5 +1,7 @@
 #include "../SoundSystem.func.hpp"
 
+#include "OpenSHC/Audio/mss/SoundFlagsAndLoopCountBitwiseFlagEnum.hpp"
+
 namespace OpenSHC {
 namespace Audio {
     namespace MSS {
@@ -12,13 +14,13 @@ namespace Audio {
             }
 
             for (int i = 0; i < 5; ++i) {
-                this->streamFlagsUnkAndLoopCount_0x34[i].uninterruptable = false;
+                this->streamFlagsUnkAndLoopCount_0x34[i] &= ~FLAG_SOUND_UNINTERRUPTABLE;
                 MACRO_CALL_MEMBER(SoundSystem_Func::endSoundStream, this)((SHC_SoundStream)i);
             }
 
-            for (int i = 0; i < 31; ++i) {
-                AIL_end_sample(this->sample_0x190[i]);
-                this->sampleSoundIndex_0x20c[i + 1] = 0;
+            for (int i = 1; i < 32; ++i) {
+                AIL_end_sample(this->sample[i]);
+                this->sampleSoundIndex_0x20c[i] = 0;
             }
 
             for (int i = 1; i < this->loadedSoundsCountAndIndex_0x316c; ++i) {

--- a/src/OpenSHC/Audio/mss/SoundSystem/endSoundStream.cpp
+++ b/src/OpenSHC/Audio/mss/SoundSystem/endSoundStream.cpp
@@ -1,6 +1,7 @@
 #include "../SoundSystem.func.hpp"
 
 #include "OpenSHC/OS.func.hpp"
+#include "OpenSHC/Audio/mss/SoundFlagsAndLoopCountBitwiseFlagEnum.hpp"
 
 #include "OpenSHC/Globals/DAT_SoundEffectsHelperData1.hpp"
 
@@ -37,7 +38,7 @@ namespace Audio {
                 return;
             }
 
-            if (this->streamFlagsUnkAndLoopCount_0x34[sndStreamIndex].uninterruptable
+            if (this->streamFlagsUnkAndLoopCount_0x34[sndStreamIndex] & FLAG_SOUND_UNINTERRUPTABLE
                 && AIL_stream_status(this->stream_0xc[sndStreamIndex]) == SMP_PLAYING) {
                 return;
             }

--- a/src/OpenSHC/Audio/mss/SoundSystem/endSpeechSoundStreams.cpp
+++ b/src/OpenSHC/Audio/mss/SoundSystem/endSpeechSoundStreams.cpp
@@ -1,5 +1,7 @@
 #include "../SoundSystem.func.hpp"
 
+#include "OpenSHC/Audio/mss/SoundFlagsAndLoopCountBitwiseFlagEnum.hpp"
+
 #include "OpenSHC/Globals/DAT_SoundSystemState.hpp"
 
 namespace OpenSHC {
@@ -12,16 +14,15 @@ namespace Audio {
             if (!this->waveOutOpenUnk_0x8) {
                 return;
             }
-            UnkSoundFlagsAndLoopCount const unkSoundFlagsAndLoopCount = { 1, 0, 0, 0, 0 };
-            this->streamFlagsUnkAndLoopCount_0x34[1] = unkSoundFlagsAndLoopCount;
-            this->streamFlagsUnkAndLoopCount_0x34[2] = unkSoundFlagsAndLoopCount;
-            this->streamFlagsUnkAndLoopCount_0x34[3].uninterruptable = false;
-            this->streamFlagsUnkAndLoopCount_0x34[4].uninterruptable = false;
+            this->streamFlagsUnkAndLoopCount_0x34[1] = 1;
+            this->streamFlagsUnkAndLoopCount_0x34[2] = 1;
+            this->streamFlagsUnkAndLoopCount_0x34[3] &= ~FLAG_SOUND_UNINTERRUPTABLE;
+            this->streamFlagsUnkAndLoopCount_0x34[4] &= ~FLAG_SOUND_UNINTERRUPTABLE;
             // Strangely only produces matching code if not using "this"
             MACRO_CALL_MEMBER(SoundSystem_Func::endSoundStream, DAT_SoundSystemState::ptr)(enums::SND_STR_SPEECH_1);
             MACRO_CALL_MEMBER(SoundSystem_Func::endSoundStream, DAT_SoundSystemState::ptr)(enums::SND_STR_SPEECH_2);
             for (int i = 1; i < 32; ++i) {
-                AIL_end_sample(this->sample_0x190[i - 1]);
+                AIL_end_sample(this->sample[i]);
                 this->sampleSoundIndex_0x20c[i] = 0;
             }
             for (int i = 1; i < this->loadedSoundsCountAndIndex_0x316c; ++i) {

--- a/src/OpenSHC/Audio/mss/SoundSystem/getAndUpdateSampleStatus.cpp
+++ b/src/OpenSHC/Audio/mss/SoundSystem/getAndUpdateSampleStatus.cpp
@@ -14,8 +14,7 @@ namespace Audio {
                 return FALSE;
             }
 
-            unsigned int const status
-                = AIL_sample_status(this->sample_0x190[this->soundFileCurrSampleNum_0x28c[soundIndex] + -1]);
+            unsigned int const status = AIL_sample_status(this->sample[this->soundFileCurrSampleNum_0x28c[soundIndex]]);
             if (status == SMP_PLAYING) {
                 return TRUE;
             }

--- a/src/OpenSHC/Audio/mss/SoundSystem/meth_0x424700.cpp
+++ b/src/OpenSHC/Audio/mss/SoundSystem/meth_0x424700.cpp
@@ -1,5 +1,6 @@
 #include "../SoundSystem.func.hpp"
 
+#include "OpenSHC/Audio/MSS/SoundFlagsAndLoopCountBitwiseFlagEnum.hpp"
 #include "OpenSHC/Audio/MSS/enums/SHC_SoundStream.hpp"
 
 namespace OpenSHC {
@@ -9,9 +10,8 @@ namespace Audio {
         // FUNCTION: STRONGHOLDCRUSADER 0x00424700
         void SoundSystem::meth_0x424700()
         {
-            UnkSoundFlagsAndLoopCount const unkSoundFlagsAndLoopCount = {};
-            this->streamFlagsUnkAndLoopCount_0x34[4] = unkSoundFlagsAndLoopCount;
-            this->streamFlagsUnkAndLoopCount_0x34[3] = unkSoundFlagsAndLoopCount;
+            this->streamFlagsUnkAndLoopCount_0x34[4] = 0;
+            this->streamFlagsUnkAndLoopCount_0x34[3] = 0;
             MACRO_CALL_MEMBER(SoundSystem_Func::endSoundStream, this)(enums::SND_STR_SPEECH_1);
             MACRO_CALL_MEMBER(SoundSystem_Func::endSoundStream, this)(enums::SND_STR_SPEECH_2);
         }

--- a/src/OpenSHC/Audio/mss/SoundSystem/meth_0x479b70.cpp
+++ b/src/OpenSHC/Audio/mss/SoundSystem/meth_0x479b70.cpp
@@ -1,5 +1,7 @@
 #include "../SoundSystem.func.hpp"
 
+#include "OpenSHC/Audio/mss/SoundFlagsAndLoopCountBitwiseFlagEnum.hpp"
+
 namespace OpenSHC {
 namespace Audio {
     namespace MSS {
@@ -8,8 +10,8 @@ namespace Audio {
         // This functions seems to reset the 0 indexed stream, most likely the music stream
         // Index 3 seems to be general NPC voices (at least)
         // Assumption:
-        // The tested flag here ("unkownFlag1" currently) might indicate that playing this sample should lower the music
-        // volume, or that the music volume is currently lowered
+        // The tested flag here ("FLAG_SOUND_UNKNOWN_FLAG_1" currently) might indicate that playing this sample should
+        // lower the music volume, or that the music volume is currently lowered
 
         // FUNCTION: STRONGHOLDCRUSADER 0x00479B70
         void SoundSystem::meth_0x479b70()
@@ -18,15 +20,15 @@ namespace Audio {
                 return;
             }
 
-            if (this->streamFlagsUnkAndLoopCount_0x34[3].unknownFlag1 && this->streamActiveUnk_0x20[3]
+            if (this->streamFlagsUnkAndLoopCount_0x34[3] & FLAG_SOUND_UNKNOWN_FLAG_1 && this->streamActiveUnk_0x20[3]
                 && AIL_stream_status(this->stream_0xc[3]) != SMP_PLAYING) {
-                this->streamFlagsUnkAndLoopCount_0x34[3].unknownFlag1 = false;
+                this->streamFlagsUnkAndLoopCount_0x34[3] &= ~FLAG_SOUND_UNKNOWN_FLAG_1;
                 AIL_set_sample_volume(
                     this->musicSampleUnk_0x170, (this->streamVolume[0] * this->streamFileVolumeNextUnk_0x48[0]) / 100);
             }
-            if (this->streamFlagsUnkAndLoopCount_0x34[4].unknownFlag1 && this->streamActiveUnk_0x20[4]
+            if (this->streamFlagsUnkAndLoopCount_0x34[4] & FLAG_SOUND_UNKNOWN_FLAG_1 && this->streamActiveUnk_0x20[4]
                 && AIL_stream_status(this->stream_0xc[4]) != SMP_PLAYING) {
-                this->streamFlagsUnkAndLoopCount_0x34[4].unknownFlag1 = false;
+                this->streamFlagsUnkAndLoopCount_0x34[4] &= ~FLAG_SOUND_UNKNOWN_FLAG_1;
                 AIL_set_sample_volume(
                     this->musicSampleUnk_0x170, (this->streamVolume[0] * this->streamFileVolumeNextUnk_0x48[0]) / 100);
             }

--- a/src/OpenSHC/Audio/mss/SoundSystem/meth_0x47a9e0.cpp
+++ b/src/OpenSHC/Audio/mss/SoundSystem/meth_0x47a9e0.cpp
@@ -1,5 +1,7 @@
 #include "../SoundSystem.func.hpp"
 
+#include "OpenSHC/Audio/mss/SoundFlagsAndLoopCountBitwiseFlagEnum.hpp"
+
 #include "OpenSHC/Globals/DAT_SoundSystemState.hpp"
 
 namespace OpenSHC {
@@ -13,13 +15,13 @@ namespace Audio {
                 return;
             }
 
-            this->streamFlagsUnkAndLoopCount_0x34[3].uninterruptable = false;
-            this->streamFlagsUnkAndLoopCount_0x34[4].uninterruptable = false;
+            this->streamFlagsUnkAndLoopCount_0x34[3] &= ~FLAG_SOUND_UNINTERRUPTABLE;
+            this->streamFlagsUnkAndLoopCount_0x34[4] &= ~FLAG_SOUND_UNINTERRUPTABLE;
             // Strangely only produces matching code if not using "this"
             MACRO_CALL_MEMBER(SoundSystem_Func::endSoundStream, DAT_SoundSystemState::ptr)(enums::SND_STR_SPEECH_1);
             MACRO_CALL_MEMBER(SoundSystem_Func::endSoundStream, DAT_SoundSystemState::ptr)(enums::SND_STR_SPEECH_2);
             for (int i = 1; i < 32; ++i) {
-                AIL_end_sample(this->sample_0x190[i - 1]);
+                AIL_end_sample(this->sample[i]);
                 this->sampleSoundIndex_0x20c[i] = 0;
             }
             for (int i = 1; i < this->loadedSoundsCountAndIndex_0x316c; ++i) {

--- a/src/OpenSHC/Audio/mss/SoundSystem/pauseAudioSample.cpp
+++ b/src/OpenSHC/Audio/mss/SoundSystem/pauseAudioSample.cpp
@@ -30,7 +30,7 @@ namespace Audio {
                 }
                 if (MACRO_CALL_MEMBER(SoundSystem_Func::getAndUpdateSampleStatus, this)(soundIndex)) {
                     this->samplePaused_0x31f4[this->soundFileCurrSampleNum_0x28c[soundIndex]] = 1;
-                    AIL_stop_sample(this->sample_0x190[this->soundFileCurrSampleNum_0x28c[soundIndex] + -1]);
+                    AIL_stop_sample(this->sample[this->soundFileCurrSampleNum_0x28c[soundIndex]]);
                 }
             }
         }

--- a/src/OpenSHC/Audio/mss/SoundSystem/playMusicUnk.cpp
+++ b/src/OpenSHC/Audio/mss/SoundSystem/playMusicUnk.cpp
@@ -2,6 +2,7 @@
 
 #include "OpenSHC/OS.func.hpp"
 #include "OpenSHC/Random/RNG.func.hpp"
+#include "OpenSHC/Audio/mss/SoundFlagsAndLoopCountBitwiseFlagEnum.hpp"
 
 #include "OpenSHC/Globals/DAT_GameCore.hpp"
 #include "OpenSHC/Globals/DAT_SFXDefinedData.hpp"
@@ -98,10 +99,10 @@ namespace Audio {
                     readFileBytes += MACRO_CALL(OS_Func::_ucrt_read)(this->musicSampleFileHandleUnk_0x174,
                         (void*)((int)this->sampleBufferPtrUnk_0x17c[_buffNum] + readFileBytes),
                         this->sampleBufferSizeUnk_0x184 - readFileBytes);
-                } else if (this->streamFlagsUnkAndLoopCount_0x34[0].loopCount == 1) {
+                } else if ((this->streamFlagsUnkAndLoopCount_0x34[0] & FLAG_SOUND_LOOP_COUNT_FIELD) == 1) {
                     MACRO_CALL_MEMBER(SoundSystem_Func::stopMusicPlayback, this)();
                     return;
-                } else if (this->streamFlagsUnkAndLoopCount_0x34[0].loopCount == 0) {
+                } else if ((this->streamFlagsUnkAndLoopCount_0x34[0] & FLAG_SOUND_LOOP_COUNT_FIELD) == 0) {
                     MACRO_CALL(OS_Func::_ucrt_lseek)(this->musicSampleFileHandleUnk_0x174, 0, FILE_BEGIN);
                     readFileBytes += MACRO_CALL(OS_Func::_ucrt_read)(this->musicSampleFileHandleUnk_0x174,
                         (void*)((int)this->sampleBufferPtrUnk_0x17c[_buffNum] + readFileBytes),

--- a/src/OpenSHC/Audio/mss/SoundSystem/playSound.cpp
+++ b/src/OpenSHC/Audio/mss/SoundSystem/playSound.cpp
@@ -1,5 +1,4 @@
 #include "OpenSHC/Audio/MSS/SoundSystem.func.hpp"
-
 #include "OpenSHC/string-literals.hpp"
 
 namespace OpenSHC {
@@ -14,10 +13,9 @@ namespace Audio {
                 return;
             }
 
-            AIL_set_named_sample_file(this->sample_0x190[this->soundFileCurrSampleNum_0x28c[soundIndex] + -1],
-                s__wav_005a6cc4, this->soundFileDataPointerArray_0x122c[soundIndex],
-                this->soundFileSizes_0x21cc[soundIndex], 0);
-            AIL_start_sample(this->sample_0x190[this->soundFileCurrSampleNum_0x28c[soundIndex] + -1]);
+            AIL_set_named_sample_file(this->sample[this->soundFileCurrSampleNum_0x28c[soundIndex]], s__wav_005a6cc4,
+                this->soundFileDataPointerArray_0x122c[soundIndex], this->soundFileSizes_0x21cc[soundIndex], 0);
+            AIL_start_sample(this->sample[this->soundFileCurrSampleNum_0x28c[soundIndex]]);
         }
 
     }

--- a/src/OpenSHC/Audio/mss/SoundSystem/setVolumeUnk.cpp
+++ b/src/OpenSHC/Audio/mss/SoundSystem/setVolumeUnk.cpp
@@ -13,13 +13,9 @@ namespace Audio {
 
             if (streamIndex == -1) {
                 this->sampleVolume = volume;
-                for (int i = 0; i < 31; ++i) {
-                    // TODO: A lot of structures of SoundSystem use an 32 element array. sample_0x190 for example
-                    //   uses 31 and might be "missing" its first element. The 0 seems to be used for "something" else
-                    //   in general. So either we should one day treat all these as "a value and a 31 element array" or
-                    //   like a single 32 array.
+                for (int i = 1; i < 32; ++i) {
                     AIL_set_sample_volume(
-                        this->sample_0x190[i], (this->sampleSndStructVolumePercentage_0x3174[i + 1] * volume) / 100);
+                        this->sample[i], (this->sampleSndStructVolumePercentage_0x3174[i] * volume) / 100);
                 }
                 return;
             }

--- a/src/OpenSHC/Audio/mss/SoundSystem/setupSampleForNextSound.cpp
+++ b/src/OpenSHC/Audio/mss/SoundSystem/setupSampleForNextSound.cpp
@@ -13,10 +13,10 @@ namespace Audio {
 
             this->sampleSndStructVolumePercentage_0x3174[this->soundFileCurrSampleNum_0x28c[soundIndex]]
                 = sampleVolumePercentage;
-            AIL_set_sample_volume(this->sample_0x190[this->soundFileCurrSampleNum_0x28c[soundIndex] + -1],
+            AIL_set_sample_volume(this->sample[this->soundFileCurrSampleNum_0x28c[soundIndex]],
                 (this->sampleVolume * sampleVolumePercentage) / 100);
-            AIL_set_sample_pan(this->sample_0x190[this->soundFileCurrSampleNum_0x28c[soundIndex] + -1], samplePan);
-            AIL_set_sample_loop_count(this->sample_0x190[this->soundFileCurrSampleNum_0x28c[soundIndex] + -1], 1);
+            AIL_set_sample_pan(this->sample[this->soundFileCurrSampleNum_0x28c[soundIndex]], samplePan);
+            AIL_set_sample_loop_count(this->sample[this->soundFileCurrSampleNum_0x28c[soundIndex]], 1);
         }
 
     }

--- a/src/OpenSHC/Audio/mss/SoundSystem/setupVolumeAndSoundID.cpp
+++ b/src/OpenSHC/Audio/mss/SoundSystem/setupVolumeAndSoundID.cpp
@@ -19,7 +19,7 @@ namespace Audio {
             // Indicator to handle as mission sound (?)
             if (soundIDInt == DE::SHCDE::MUSIC_TUNE_NARR1) {
                 // missionNumber1to20 might be unsigned, but found signs inconclusive
-                if (DAT_GameCore::ptr->missionNumber1to20 - 1U <= 19) {
+                if (1 <= DAT_GameCore::ptr->missionNumber1to20 && DAT_GameCore::ptr->missionNumber1to20 <= 20) {
                     // This makes the soundID "missionNumber1to20 + 46", which would use the enums 47 to 66.
                     // These are only filled by 4 enums for 4 mission intros, so this space could be made for 20.
                     soundIDInt = DAT_GameCore::ptr->missionNumber1to20 + 46;

--- a/src/OpenSHC/Audio/mss/SoundSystem/setupVolumeAndSoundIDWithMultiplier.cpp
+++ b/src/OpenSHC/Audio/mss/SoundSystem/setupVolumeAndSoundIDWithMultiplier.cpp
@@ -19,7 +19,7 @@ namespace Audio {
             // Indicator to handle as mission sound (?)
             if (soundIDInt == DE::SHCDE::MUSIC_TUNE_NARR1) {
                 // missionNumber1to20 might be unsigned, but found signs inconclusive
-                if (DAT_GameCore::ptr->missionNumber1to20 - 1U <= 19) {
+                if (1 <= DAT_GameCore::ptr->missionNumber1to20 && DAT_GameCore::ptr->missionNumber1to20 <= 20) {
                     // This makes the soundID "missionNumber1to20 + 46", which would use the enums 47 to 66.
                     // These are only filled by 4 enums for 4 mission intros, so this space could be made for 20.
                     soundIDInt = DAT_GameCore::ptr->missionNumber1to20 + 46;

--- a/src/OpenSHC/Audio/mss/SoundSystem/shutdownSoundSystem.cpp
+++ b/src/OpenSHC/Audio/mss/SoundSystem/shutdownSoundSystem.cpp
@@ -18,19 +18,18 @@ namespace Audio {
             }
 
             MACRO_CALL_MEMBER(Rendering::Bink::BinkControlClass_Func::stopAllBinkPlayback, DAT_BinkControlState::ptr)();
-            if (DAT_SFXDefinedData::ptr->SND_SomeTimerIdentifier != 0xffffffff) {
+            if (DAT_SFXDefinedData::ptr->SND_SomeTimerIdentifier != UINT_MAX) {
                 timeKillEvent(DAT_SFXDefinedData::ptr->SND_SomeTimerIdentifier);
                 timeEndPeriod(DAT_SoundEffectsHelperData1::ptr->SND_SomeTimerResolution);
-                DAT_SFXDefinedData::ptr->SND_SomeTimerIdentifier = 0xffffffff;
+                DAT_SFXDefinedData::ptr->SND_SomeTimerIdentifier = UINT_MAX;
             }
             for (int i = 0; i < 5; ++i) {
-                UnkSoundFlagsAndLoopCount const unkSoundFlagsAndLoopCount = { 0, 0, 0, 0, 0 };
-                this->streamFlagsUnkAndLoopCount_0x34[i] = unkSoundFlagsAndLoopCount;
+                this->streamFlagsUnkAndLoopCount_0x34[i] = 0;
                 MACRO_CALL_MEMBER(SoundSystem_Func::endSoundStream, this)((SHC_SoundStream)i);
             }
-            for (int i = 0; i < 31; ++i) {
-                AIL_end_sample(this->sample_0x190[i]);
-                AIL_release_sample_handle(this->sample_0x190[i]);
+            for (int i = 1; i < 32; ++i) {
+                AIL_end_sample(this->sample[i]);
+                AIL_release_sample_handle(this->sample[i]);
             }
             for (int i = 1; i < this->loadedSoundsCountAndIndex_0x316c; ++i) {
                 if (this->soundFileDataPointerArray_0x122c[i]) {


### PR DESCRIPTION
`UnkSoundFlagsAndLoopCount` can be removed, I think. The enums for fine so far.