### PR TITLE
feat: allow to disable wrapper stdout

### DIFF
--- a/build.bat
+++ b/build.bat
@@ -1,12 +1,22 @@
 @echo off
 setlocal EnableDelayedExpansion
 
+:: --------------------------------------------
+:: Optional wrapper arguments
+:: --------------------------------------------
+if /i "%~1"=="--wrap-quiet" (
+    set "WRAP_QUIET=1"
+    shift
+)
+
 :: --- Validate preset parameter (required) ---
 if "%~1"=="" (
-    echo [ERROR] Preset not specified.
-    echo Usage: %~nx0 ^<Preset^> [Target]
-    echo   ^<Preset^> : Required. The CMake configure/build preset to use.
-    echo   [Target]   : Optional. The specific target to build. If omitted, the default target will be built.
+    if not defined WRAP_QUIET (
+        echo [ERROR] Preset not specified.
+        echo Usage: %~nx0 [--wrap-quiet] ^<Preset^> [Target]
+        echo   ^<Preset^> : Required. The CMake configure/build preset to use.
+        echo   [Target] : Optional. The specific target to build. If omitted, the default target will be built.
+    )
     exit /b 1
 )
 
@@ -16,36 +26,36 @@ set "TARGET=%~2"
 :: --- Kill mspdbsrv.exe if it's running ---
 tasklist | find /I "mspdbsrv.exe" >nul
 if not errorlevel 1 (
-    echo Stopping mspdbsrv.exe...
+    if not defined WRAP_QUIET echo Stopping mspdbsrv.exe...
     taskkill /f /t /im mspdbsrv.exe >nul
     if errorlevel 1 (
-        echo [WARNING] Failed to stop mspdbsrv.exe, continuing...
+        if not defined WRAP_QUIET echo [WARNING] Failed to stop mspdbsrv.exe, continuing...
     )
 )
 
 :: --- Run cmake configure using preset ---
-echo [INFO] Configuring with preset "%PRESET%"...
+if not defined WRAP_QUIET echo [INFO] Configuring with preset "%PRESET%"...
 call .\cmakew --preset "%PRESET%"
 if errorlevel 1 (
-    echo [ERROR] CMake configure failed for preset "%PRESET%".
+    if not defined WRAP_QUIET echo [ERROR] CMake configure failed for preset "%PRESET%".
     exit /b 1
 )
 
 :: --- Run cmake build using preset ---
 if "%TARGET%"=="" (
-    echo [INFO] Building preset "%PRESET%" with default target...
+    if not defined WRAP_QUIET echo [INFO] Building preset "%PRESET%" with default target...
     call .\cmakew --build --preset "%PRESET%"
     if errorlevel 1 (
-        echo [ERROR] CMake build failed for preset "%PRESET%".
+        if not defined WRAP_QUIET echo [ERROR] CMake build failed for preset "%PRESET%".
         exit /b 1
     )
-    echo Build completed successfully for preset "%PRESET%".
+    if not defined WRAP_QUIET echo Build completed successfully for preset "%PRESET%".
 ) else (
-    echo [INFO] Building preset "%PRESET%" with target "%TARGET%"...
+    if not defined WRAP_QUIET echo [INFO] Building preset "%PRESET%" with target "%TARGET%"...
     call .\cmakew --build --preset "%PRESET%" --target "%TARGET%"
     if errorlevel 1 (
-        echo [ERROR] CMake build failed for preset "%PRESET%" target "%TARGET%".
+        if not defined WRAP_QUIET echo [ERROR] CMake build failed for preset "%PRESET%" target "%TARGET%".
         exit /b 1
     )
-    echo Build completed successfully for preset "%PRESET%" target "%TARGET%".
+    if not defined WRAP_QUIET echo Build completed successfully for preset "%PRESET%" target "%TARGET%".
 )

--- a/cmakew.bat
+++ b/cmakew.bat
@@ -1,13 +1,20 @@
 @echo off
 setlocal EnableDelayedExpansion
 
+:: --- Optional wrapper arguments
+set "ARGS=%*"
+if /i "%~1"=="--wrap-quiet" (
+    set "WRAP_QUIET=1"
+    set "ARGS=!ARGS:--wrap-quiet=!"
+)
+
 :: --- Check if cmake is in PATH ---
 where cmake >nul 2>nul
 if errorlevel 1 (
-    echo [INFO] Auto-detecting cmake location using vswhere.
+    if not defined WRAP_QUIET echo [INFO] Auto-detecting cmake location using vswhere.
 
     if not exist "C:\Program Files (x86)\Microsoft Visual Studio\Installer\vswhere.exe" (
-        echo [ERROR] 'vswhere' not found, cannot locate 'cmake'.
+        if not defined WRAP_QUIET echo [ERROR] 'vswhere' not found, cannot locate 'cmake'.
         exit /b 1
     )
 
@@ -24,14 +31,14 @@ if errorlevel 1 (
     )
 
     if not exist "!CMAKE!" (
-        echo [ERROR] 'cmake' not found in PATH and not found using vswhere.
+        if not defined WRAP_QUIET echo [ERROR] 'cmake' not found in PATH and not found using vswhere.
         exit /b 1
     )
 
-    echo [INFO] Detected: "!CMAKE!"
+    if not defined WRAP_QUIET echo [INFO] Detected: "!CMAKE!"
     set "PATH=!CMAKE!;%PATH%"
 )
 
 :: --- Proxy all arguments to actual CMake ---
-cmake %*
+cmake !ARGS!
 exit /b %errorlevel%

--- a/reccmp/dll/run.bat
+++ b/reccmp/dll/run.bat
@@ -7,10 +7,19 @@ set "ENV_ACTIVE=0"
 set "CMD_EXIT_CODE=0"
 
 :: --------------------------------------------
+:: Optional wrapper arguments
+:: --------------------------------------------
+set "ARGS=%*"
+if /i "%~1"=="--wrap-quiet" (
+    set "WRAP_QUIET=1"
+    set "ARGS=%ARGS:--wrap-quiet=%"
+)
+
+:: --------------------------------------------
 :: Change working directory to script location
 :: --------------------------------------------
 cd /d "%~dp0" || (
-    echo [ERROR] Failed to set working directory to script location.
+    if not defined WRAP_QUIET echo [ERROR] Failed to set working directory to script location.
     call :Cleanup
     exit /b 1
 )
@@ -18,9 +27,11 @@ cd /d "%~dp0" || (
 :: --------------------------------------------
 :: Check arguments
 :: --------------------------------------------
-if "%~1"=="" (
-    echo [ERROR] No command provided.
-    echo Usage: %~nx0 command [args...]
+if "%ARGS%"=="" (
+    if not defined WRAP_QUIET (
+        echo [ERROR] No command provided.
+        echo Usage: %~nx0 [--wrap-quiet] command [args...]
+    )
     call :Cleanup
     exit /b 1
 )
@@ -29,8 +40,10 @@ if "%~1"=="" (
 :: Check virtual environment exists
 :: --------------------------------------------
 if not exist "%VENV_DIR%\Scripts\activate.bat" (
-    echo [ERROR] Virtual environment not found: %VENV_DIR%
-    echo Please run the setup script first.
+    if not defined WRAP_QUIET (
+        echo [ERROR] Virtual environment not found: %VENV_DIR%
+        echo Please run the setup script first.
+    )
     call :Cleanup
     exit /b 1
 )
@@ -39,7 +52,7 @@ if not exist "%VENV_DIR%\Scripts\activate.bat" (
 :: Prevent double-activation
 :: --------------------------------------------
 if /i "%VIRTUAL_ENV%"=="%CD%\%VENV_DIR%" (
-    echo [ERROR] Already running inside the target virtual environment.
+    if not defined WRAP_QUIET echo [ERROR] Already running inside the target virtual environment.
     call :Cleanup
     exit /b 1
 )
@@ -49,22 +62,22 @@ if /i "%VIRTUAL_ENV%"=="%CD%\%VENV_DIR%" (
 :: --------------------------------------------
 call "%VENV_DIR%\Scripts\activate.bat"
 if /i not "%VIRTUAL_ENV%"=="%CD%\%VENV_DIR%" (
-    echo [ERROR] Failed to activate virtual environment.
+    if not defined WRAP_QUIET echo [ERROR] Failed to activate virtual environment.
     call :Cleanup
     exit /b 1
 )
 
 set "ENV_ACTIVE=1"
-echo [OK] Virtual environment activated.
+if not defined WRAP_QUIET echo [OK] Virtual environment activated.
 
 :: --------------------------------------------
 :: Run provided command
 :: --------------------------------------------
-echo [INFO] Running command: %*
-cmd /c %*
+if not defined WRAP_QUIET echo [INFO] Running command: %ARGS%
+cmd /c %ARGS%
 set "CMD_EXIT_CODE=%ERRORLEVEL%"
 if %CMD_EXIT_CODE% neq 0 (
-    echo [ERROR] Command failed with exit code %CMD_EXIT_CODE%.
+    if not defined WRAP_QUIET echo [ERROR] Command failed with exit code %CMD_EXIT_CODE%.
     call :Cleanup
     exit /b %CMD_EXIT_CODE%
 )
@@ -74,7 +87,7 @@ if %CMD_EXIT_CODE% neq 0 (
 :: --------------------------------------------
 call :Cleanup
 
-echo [SUCCESS] Command completed successfully.
+if not defined WRAP_QUIET echo [SUCCESS] Command completed successfully.
 exit /b 0
 
 :: --------------------------------------------
@@ -84,6 +97,6 @@ exit /b 0
 if "%ENV_ACTIVE%"=="1" (
     deactivate
     set "ENV_ACTIVE=0"
-    echo [OK] Virtual environment deactivated.
+    if not defined WRAP_QUIET echo [OK] Virtual environment deactivated.
 )
 exit /b 0

--- a/reccmp/exe/run.bat
+++ b/reccmp/exe/run.bat
@@ -7,10 +7,19 @@ set "ENV_ACTIVE=0"
 set "CMD_EXIT_CODE=0"
 
 :: --------------------------------------------
+:: Optional wrapper arguments
+:: --------------------------------------------
+set "ARGS=%*"
+if /i "%~1"=="--wrap-quiet" (
+    set "WRAP_QUIET=1"
+    set "ARGS=%ARGS:--wrap-quiet=%"
+)
+
+:: --------------------------------------------
 :: Change working directory to script location
 :: --------------------------------------------
 cd /d "%~dp0" || (
-    echo [ERROR] Failed to set working directory to script location.
+    if not defined WRAP_QUIET echo [ERROR] Failed to set working directory to script location.
     call :Cleanup
     exit /b 1
 )
@@ -18,9 +27,11 @@ cd /d "%~dp0" || (
 :: --------------------------------------------
 :: Check arguments
 :: --------------------------------------------
-if "%~1"=="" (
-    echo [ERROR] No command provided.
-    echo Usage: %~nx0 command [args...]
+if "%ARGS%"=="" (
+    if not defined WRAP_QUIET (
+        echo [ERROR] No command provided.
+        echo Usage: %~nx0 [--wrap-quiet] command [args...]
+    )
     call :Cleanup
     exit /b 1
 )
@@ -29,8 +40,10 @@ if "%~1"=="" (
 :: Check virtual environment exists
 :: --------------------------------------------
 if not exist "%VENV_DIR%\Scripts\activate.bat" (
-    echo [ERROR] Virtual environment not found: %VENV_DIR%
-    echo Please run the setup script first.
+    if not defined WRAP_QUIET (
+        echo [ERROR] Virtual environment not found: %VENV_DIR%
+        echo Please run the setup script first.
+    )
     call :Cleanup
     exit /b 1
 )
@@ -39,7 +52,7 @@ if not exist "%VENV_DIR%\Scripts\activate.bat" (
 :: Prevent double-activation
 :: --------------------------------------------
 if /i "%VIRTUAL_ENV%"=="%CD%\%VENV_DIR%" (
-    echo [ERROR] Already running inside the target virtual environment.
+    if not defined WRAP_QUIET echo [ERROR] Already running inside the target virtual environment.
     call :Cleanup
     exit /b 1
 )
@@ -49,22 +62,22 @@ if /i "%VIRTUAL_ENV%"=="%CD%\%VENV_DIR%" (
 :: --------------------------------------------
 call "%VENV_DIR%\Scripts\activate.bat"
 if /i not "%VIRTUAL_ENV%"=="%CD%\%VENV_DIR%" (
-    echo [ERROR] Failed to activate virtual environment.
+    if not defined WRAP_QUIET echo [ERROR] Failed to activate virtual environment.
     call :Cleanup
     exit /b 1
 )
 
 set "ENV_ACTIVE=1"
-echo [OK] Virtual environment activated.
+if not defined WRAP_QUIET echo [OK] Virtual environment activated.
 
 :: --------------------------------------------
 :: Run provided command
 :: --------------------------------------------
-echo [INFO] Running command: %*
-cmd /c %*
+if not defined WRAP_QUIET echo [INFO] Running command: %ARGS%
+cmd /c %ARGS%
 set "CMD_EXIT_CODE=%ERRORLEVEL%"
 if %CMD_EXIT_CODE% neq 0 (
-    echo [ERROR] Command failed with exit code %CMD_EXIT_CODE%.
+    if not defined WRAP_QUIET echo [ERROR] Command failed with exit code %CMD_EXIT_CODE%.
     call :Cleanup
     exit /b %CMD_EXIT_CODE%
 )
@@ -74,7 +87,7 @@ if %CMD_EXIT_CODE% neq 0 (
 :: --------------------------------------------
 call :Cleanup
 
-echo [SUCCESS] Command completed successfully.
+if not defined WRAP_QUIET echo [SUCCESS] Command completed successfully.
 exit /b 0
 
 :: --------------------------------------------
@@ -84,6 +97,6 @@ exit /b 0
 if "%ENV_ACTIVE%"=="1" (
     deactivate
     set "ENV_ACTIVE=0"
-    echo [OK] Virtual environment deactivated.
+    if not defined WRAP_QUIET echo [OK] Virtual environment deactivated.
 )
 exit /b 0


### PR DESCRIPTION
Add way to non-setup scripts to disable the outputs of the scripts, leaving only the output of the underlying calls.