### PR TITLE
reimplement: SHC_3BB0A8C1_0x0044AE90 100%

### DIFF
--- a/src/OpenSHC/Audio/SFX/SFXState/readVolumeFileAndSetupSoundVolumes.cpp
+++ b/src/OpenSHC/Audio/SFX/SFXState/readVolumeFileAndSetupSoundVolumes.cpp
@@ -24,7 +24,6 @@ namespace Audio {
             long const _Size = MACRO_CALL(OS_Func::_ftell)(_File);
             MACRO_CALL(OS_Func::_fseek)(_File, 0, FILE_BEGIN);
 
-            // Maybe it is not char*?
             this->DAT_SoundFileNameArrayMemoryPointer = (char*)MACRO_CALL(OS_Func::_malloc)(_Size);
             MACRO_CALL(OS_Func::_fread)(this->DAT_SoundFileNameArrayMemoryPointer, 1, _Size, _File);
             MACRO_CALL(OS_Func::_fclose)(_File);
@@ -118,33 +117,35 @@ namespace Audio {
                     }
                     this->DAT_SoundVolumeArray[soundIndex] = 0;
 
-                    // Read numbers by: Reading first char, transform to int (-48) and then combine with (previous
-                    // int * 10), to handle number index.
+                    // Read numbers by: Reading first char, transform to int (-48) and then combine with previous
+                    // int * 10, to handle number index.
                     while ('0' <= this->DAT_SoundFileNameArrayMemoryPointer[fileIndex]
                         && this->DAT_SoundFileNameArrayMemoryPointer[fileIndex] <= '9') {
                         this->DAT_SoundVolumeArray[soundIndex] *= 10;
                         this->DAT_SoundVolumeArray[soundIndex]
                             += this->DAT_SoundFileNameArrayMemoryPointer[fileIndex] - 48;
                         ++fileIndex;
-                        if (fileIndex >= _Size) {
-                            this->DAT_SoundVolumeArray[soundIndex] += volume;
-                            if (this->DAT_SoundVolumeArray[soundIndex] < 0) {
-                                this->DAT_SoundVolumeArray[soundIndex] = 0;
-                            }
-                            if (127 < this->DAT_SoundVolumeArray[soundIndex]) {
-                                this->DAT_SoundVolumeArray[soundIndex] = 127;
-                            }
-                            goto break_parse;
+                        if (fileIndex < _Size) {
+                            continue;
                         }
+                        this->DAT_SoundVolumeArray[soundIndex] += volume;
+                        if (this->DAT_SoundVolumeArray[soundIndex] < 0) {
+                            this->DAT_SoundVolumeArray[soundIndex] = 0;
+                        }
+                        if (127 < this->DAT_SoundVolumeArray[soundIndex]) {
+                            this->DAT_SoundVolumeArray[soundIndex] = 127;
+                        }
+                        goto break_parse;
                     }
 
-                    // TODO: Register issues? Creating a temporary after sum produces the fitting structure, but messes
-                    // up all other registers.
                     this->DAT_SoundVolumeArray[soundIndex] += volume;
-                    if (this->DAT_SoundVolumeArray[soundIndex] < 0) {
-                        this->DAT_SoundVolumeArray[soundIndex] = 0;
-                    } else if (127 < this->DAT_SoundVolumeArray[soundIndex]) {
-                        this->DAT_SoundVolumeArray[soundIndex] = 127;
+
+                    // Applies enough register pressure to produce the fitting opcodes, but does not look very nice
+                    int& volumeRef = this->DAT_SoundVolumeArray[soundIndex];
+                    if (volumeRef < 0) {
+                        volumeRef = 0;
+                    } else if (127 < volumeRef) {
+                        volumeRef = 127;
                     }
                     while (this->DAT_SoundFileNameArrayMemoryPointer[fileIndex] != '\n'
                         && this->DAT_SoundFileNameArrayMemoryPointer[fileIndex] != '\r') {

--- a/src/OpenSHC/Audio/SFX/SFXState/readVolumeFileAndSetupSoundVolumes.cpp
+++ b/src/OpenSHC/Audio/SFX/SFXState/readVolumeFileAndSetupSoundVolumes.cpp
@@ -1,0 +1,187 @@
+#include "../SFXState.func.hpp"
+
+#include "OpenSHC/OS.func.hpp"
+#include "OpenSHC/string-literals.hpp"
+
+#include "OpenSHC/Globals/DAT_SpeechDefinedData.hpp"
+
+namespace OpenSHC {
+namespace Audio {
+    namespace SFX {
+
+        // FUNCTION: STRONGHOLDCRUSADER 0x0044AE90
+        void SFXState::readVolumeFileAndSetupSoundVolumes()
+        {
+            if (this->DAT_SoundFileNameArrayMemoryPointer) {
+                MACRO_CALL(OS_Func::_free_base)(this->DAT_SoundFileNameArrayMemoryPointer);
+            }
+            FILE* _File = MACRO_CALL(OS_Func::_fopen)(s_fx_volume_txt_005a4e08, s_rb_005a4e18);
+            if (!_File) {
+                return;
+            }
+
+            MACRO_CALL(OS_Func::_fseek)(_File, 0, FILE_END);
+            long const _Size = MACRO_CALL(OS_Func::_ftell)(_File);
+            MACRO_CALL(OS_Func::_fseek)(_File, 0, FILE_BEGIN);
+
+            // Maybe it is not char*?
+            this->DAT_SoundFileNameArrayMemoryPointer = (char*)MACRO_CALL(OS_Func::_malloc)(_Size);
+            MACRO_CALL(OS_Func::_fread)(this->DAT_SoundFileNameArrayMemoryPointer, 1, _Size, _File);
+            MACRO_CALL(OS_Func::_fclose)(_File);
+
+            int fileIndex = 0;
+            int soundIndex = 0;
+            int volume = 0;
+            while (fileIndex < _Size) {
+                while (fileIndex < _Size) {
+                    while (this->DAT_SoundFileNameArrayMemoryPointer[fileIndex] != '-'
+                        && this->DAT_SoundFileNameArrayMemoryPointer[fileIndex] != '\"') {
+                        ++fileIndex;
+                        if (fileIndex >= _Size)
+                            goto break_parse;
+                    }
+                    if (this->DAT_SoundFileNameArrayMemoryPointer[fileIndex] != '-') {
+                        break;
+                    }
+                    volume = 0;
+                    do {
+                        ++fileIndex;
+                        if (fileIndex >= _Size)
+                            goto break_parse;
+                    } while (this->DAT_SoundFileNameArrayMemoryPointer[fileIndex] < '0'
+                        || '9' < this->DAT_SoundFileNameArrayMemoryPointer[fileIndex]);
+
+                    while ('0' <= this->DAT_SoundFileNameArrayMemoryPointer[fileIndex]
+                        && this->DAT_SoundFileNameArrayMemoryPointer[fileIndex] <= '9') {
+                        ++fileIndex;
+                        if (fileIndex >= _Size)
+                            goto break_parse;
+                    }
+
+                    do {
+                        ++fileIndex;
+                        if (fileIndex >= _Size)
+                            goto break_parse;
+                    } while (this->DAT_SoundFileNameArrayMemoryPointer[fileIndex] < '0'
+                        || '9' < this->DAT_SoundFileNameArrayMemoryPointer[fileIndex]);
+
+                    int isNegative = FALSE;
+                    if (this->DAT_SoundFileNameArrayMemoryPointer[fileIndex - 1] == '-') {
+                        isNegative = TRUE;
+                    }
+                    while ('0' <= this->DAT_SoundFileNameArrayMemoryPointer[fileIndex]
+                        && this->DAT_SoundFileNameArrayMemoryPointer[fileIndex] <= '9') {
+                        volume *= 10;
+                        volume += this->DAT_SoundFileNameArrayMemoryPointer[fileIndex] - 48;
+                        ++fileIndex;
+                        if (fileIndex >= _Size)
+                            goto break_parse;
+                    }
+                    if (isNegative) {
+                        volume = -volume;
+                    }
+
+                    while (this->DAT_SoundFileNameArrayMemoryPointer[fileIndex] != '\n'
+                        && this->DAT_SoundFileNameArrayMemoryPointer[fileIndex] != '\r') {
+                        ++fileIndex;
+                        if (fileIndex >= _Size)
+                            goto break_parse;
+                    }
+                }
+
+                while (fileIndex < _Size) {
+                    if (this->DAT_SoundFileNameArrayMemoryPointer[fileIndex] != '\"') {
+                        break;
+                    }
+                    ++fileIndex;
+                    this->DAT_SoundFileNamePointersArray[soundIndex]
+                        = this->DAT_SoundFileNameArrayMemoryPointer + fileIndex;
+                    while (this->DAT_SoundFileNameArrayMemoryPointer[fileIndex] != '\"'
+                        && this->DAT_SoundFileNameArrayMemoryPointer[fileIndex] != '\r'
+                        && this->DAT_SoundFileNameArrayMemoryPointer[fileIndex] != '\n') {
+
+                        this->DAT_SoundFileNameArrayMemoryPointer[fileIndex] = (char)MACRO_CALL(OS_Func::__tolower)(
+                            this->DAT_SoundFileNameArrayMemoryPointer[fileIndex]);
+                        ++fileIndex;
+                        if (fileIndex >= _Size)
+                            goto break_parse;
+                    }
+                    if (this->DAT_SoundFileNameArrayMemoryPointer[fileIndex] == '\"') {
+                        this->DAT_SoundFileNameArrayMemoryPointer[fileIndex] = '\0';
+                    }
+                    ++fileIndex;
+                    while (this->DAT_SoundFileNameArrayMemoryPointer[fileIndex] == ' '
+                        || this->DAT_SoundFileNameArrayMemoryPointer[fileIndex] == '\t') {
+                        ++fileIndex;
+                        if (fileIndex >= _Size)
+                            goto break_parse;
+                    }
+                    this->DAT_SoundVolumeArray[soundIndex] = 0;
+
+                    // Read numbers by: Reading first char, transform to int (-48) and then combine with (previous
+                    // int * 10), to handle number index.
+                    while ('0' <= this->DAT_SoundFileNameArrayMemoryPointer[fileIndex]
+                        && this->DAT_SoundFileNameArrayMemoryPointer[fileIndex] <= '9') {
+                        this->DAT_SoundVolumeArray[soundIndex] *= 10;
+                        this->DAT_SoundVolumeArray[soundIndex]
+                            += this->DAT_SoundFileNameArrayMemoryPointer[fileIndex] - 48;
+                        ++fileIndex;
+                        if (fileIndex >= _Size) {
+                            this->DAT_SoundVolumeArray[soundIndex] += volume;
+                            if (this->DAT_SoundVolumeArray[soundIndex] < 0) {
+                                this->DAT_SoundVolumeArray[soundIndex] = 0;
+                            }
+                            if (127 < this->DAT_SoundVolumeArray[soundIndex]) {
+                                this->DAT_SoundVolumeArray[soundIndex] = 127;
+                            }
+                            goto break_parse;
+                        }
+                    }
+
+                    // TODO: Register issues? Creating a temporary after sum produces the fitting structure, but messes
+                    // up all other registers.
+                    this->DAT_SoundVolumeArray[soundIndex] += volume;
+                    if (this->DAT_SoundVolumeArray[soundIndex] < 0) {
+                        this->DAT_SoundVolumeArray[soundIndex] = 0;
+                    } else if (127 < this->DAT_SoundVolumeArray[soundIndex]) {
+                        this->DAT_SoundVolumeArray[soundIndex] = 127;
+                    }
+                    while (this->DAT_SoundFileNameArrayMemoryPointer[fileIndex] != '\n'
+                        && this->DAT_SoundFileNameArrayMemoryPointer[fileIndex] != '\r') {
+                        ++fileIndex;
+                        if (fileIndex >= _Size)
+                            goto break_parse;
+                    }
+                    while (this->DAT_SoundFileNameArrayMemoryPointer[fileIndex] == '\n'
+                        || this->DAT_SoundFileNameArrayMemoryPointer[fileIndex] == '\r') {
+                        ++fileIndex;
+                        if (fileIndex >= _Size)
+                            goto break_parse;
+                    }
+                    ++soundIndex;
+                }
+            }
+        break_parse:
+
+            this->DAT_SoundTotalCount = soundIndex;
+
+            for (int i = 0; i < 1000; ++i) {
+                if (!this->DAT_SoundStructures[i].pointerToFilename) {
+                    continue;
+                }
+                this->DAT_SoundStructures[i].baseVolumePercentageUnk = MACRO_CALL_MEMBER(
+                    SFXState_Func::getSoundVolumeForFilename, this)(this->DAT_SoundStructures[i].pointerToFilename);
+            }
+
+            for (int i = 0; i < 10; ++i) {
+                for (int j = 0; j < 8; ++j) {
+                    DAT_SpeechDefinedData::instance.field5_0x41eb04[i].volumeUnk_0x28[j]
+                        = MACRO_CALL_MEMBER(SFXState_Func::getSoundVolumeForFilename, this)(
+                            DAT_SpeechDefinedData::instance.field5_0x41eb04[i].ambientWavs_0x8[j]);
+                }
+            }
+        }
+
+    }
+}
+}

--- a/src/OpenSHC/OS/OS.cpp
+++ b/src/OpenSHC/OS/OS.cpp
@@ -67,7 +67,7 @@ namespace OS {
     int __cdecl _fseek(FILE* _File, long _Offset, DWORD _Origin) { return fseek(_File, _Offset, _Origin); }
 
     // STUB: STRONGHOLDCRUSADER 0x005804CD
-    FILE* _fopen(char* _Filename, char* _Mode) { return fopen(_Filename, _Mode); }
+    FILE* _fopen(char const* _Filename, char const* _Mode) { return fopen(_Filename, _Mode); }
 
     // STUB: STRONGHOLDCRUSADER 0x00580577
     int __vswprintf(wchar_t* _Dest, wchar_t* _Format, va_list _Args) { return _vswprintf(_Dest, _Format, _Args); }

--- a/status/addresses-SHC-3BB0A8C1.txt
+++ b/status/addresses-SHC-3BB0A8C1.txt
@@ -16307,7 +16307,7 @@ SHC_3BB0A8C1_0x0044AB70 | 100.0% | Reimplemented, requires SHC_3BB0A8C1_0x0044A0
 
 SHC_3BB0A8C1_0x0044ABB0 | 100.0% | Reimplemented, mismatches in float constants and functions 
 
-SHC_3BB0A8C1_0x0044AE90 | 0.0% | Pending
+SHC_3BB0A8C1_0x0044AE90 | 100.0% | Reimplemented
 
 SHC_3BB0A8C1_0x0044B210 | 100.0% | Reimplemented, Security Cookie mismatches
 


### PR DESCRIPTION
~Has a familiar issue:~
- ~One structure does not produce the fitting opcode structure.~
- ~Creating something that does messes up most other registers.~
- ~So either I require something to make the "messed up" situation work, or the initial mismatch might actually be related to some other pressure.~

Ha, not this time. Managed to pressure it into the right opcode. Feels a bit "wrong" code-wise, but whatever.