### PR TITLE
reimplement: SHC_3BB0A8C1_0x0044BCA0 100%

### DIFF
--- a/src/OpenSHC/Audio/SFX/SFXState/loadSFX.cpp
+++ b/src/OpenSHC/Audio/SFX/SFXState/loadSFX.cpp
@@ -1,0 +1,26 @@
+#include "../SFXState.func.hpp"
+
+#include "OpenSHC/Globals/DAT_SpeechDefinedData.hpp"
+#include "OpenSHC/Globals/DAT_TextureRenderCoreObject.hpp"
+
+namespace OpenSHC {
+namespace Audio {
+    namespace SFX {
+
+        // FUNCTION: STRONGHOLDCRUSADER 0x0044BCA0
+        void SFXState::loadSFX(int param_1)
+        {
+            if (!DAT_TextureRenderCoreObject::instance.unknownSfxAndGmRelatedFlag) {
+                MACRO_CALL_MEMBER(SFXState_Func::loadWavSounds, this)(
+                    (char*)DAT_SpeechDefinedData::instance.SFX_WavFileGroups[0]);
+                MACRO_CALL_MEMBER(SFXState_Func::readVolumeFileAndSetupSoundVolumes, this)();
+            } else {
+                MACRO_CALL_MEMBER(SFXState_Func::loadWavSounds, this)(
+                    (char*)(DAT_SpeechDefinedData::instance.SFX_WavFileGroups[1]));
+                MACRO_CALL_MEMBER(SFXState_Func::readVolumeFileAndSetupSoundVolumes, this)();
+            }
+        }
+
+    }
+}
+}

--- a/status/addresses-SHC-3BB0A8C1.txt
+++ b/status/addresses-SHC-3BB0A8C1.txt
@@ -16521,7 +16521,7 @@ SHC_3BB0A8C1_0x0044B840 | 84.0% | Reimplemented, but heavy register mismatch. Lo
 
 SHC_3BB0A8C1_0x0044B890 | 0.0% | Pending
 
-SHC_3BB0A8C1_0x0044BCA0 | 0.0% | Pending
+SHC_3BB0A8C1_0x0044BCA0 | 100.0% | Reimplemented
 
 SHC_3BB0A8C1_0x0044BCE0 | 0.0% | Pending
 


### PR DESCRIPTION
Once again a missed unused value.