### PR TITLE
Reimplement host synchronization checks and periodic messages

### DIFF
--- a/src/OpenSHC/Synchrony/GameSynchronyState/checkGameSync.cpp
+++ b/src/OpenSHC/Synchrony/GameSynchronyState/checkGameSync.cpp
@@ -1,0 +1,59 @@
+#include "../GameSynchronyState.func.hpp"
+
+#include "OpenSHC/Globals/DAT_GameSynchronyState.hpp"
+
+namespace OpenSHC {
+namespace Synchrony {
+    // FUNCTION: STRONGHOLDCRUSADER 0x0048CB00
+    void GameSynchronyState::checkGameSync()
+    {
+        int referenceHash = 0;
+        int referenceTime = 0;
+        if (DAT_HashCountdown == 0) {
+            DAT_GameHalted = 0;
+            for (int player = 1; player < 9; ++player) {
+                if (currentPlayerFullIDArray[player] != -1 && unknownPlayerInfo_03[player] == 0) {
+                    referenceHash = HASH_HashTotal[player];
+                    referenceTime = DAT_PlayerMatchTimes[player];
+                    break;
+                }
+            }
+
+            if (DAT_GameSynchronyState::instance.isHost && flag_0xbec == 0) {
+                // Wait until every participating peer has supplied a usable sample.
+                for (int player = 1; player < 9; ++player) {
+                    if (currentPlayerFullIDArray[player] != -1 && unknownPlayerInfo_03[player] == 0) {
+                        if (HASH_HashTotal[player] == 0 || DAT_PlayerMatchTimes[player] < 10) {
+                            return;
+                        }
+                    }
+                }
+
+                for (int player = 1; player < 9; ++player) {
+                    if (currentPlayerFullIDArray[player] != -1 && unknownPlayerInfo_03[player] == 0) {
+                        if (HASH_HashTotal[player] == 0) {
+                            return;
+                        }
+                        // Different advertised ticks are not a comparable state pair.
+                        if (DAT_PlayerMatchTimes[player] == referenceTime && HASH_HashTotal[player] != referenceHash) {
+                            if (syncRelatedCountdown != 0) {
+                                syncRelatedCountdown = 0;
+                                commandDelay = 30;
+                            }
+                            MACRO_CALL_MEMBER(GameSynchronyState_Func::queueCommand, DAT_GameSynchronyState::ptr)(
+                                OpenSHC::Commands::GCT_GAME_DESYNCUnk);
+                            flag_0xbec = 1;
+                            for (int slot = 1; slot < 9; ++slot) {
+                                receivedSyncStatusByPlayerUnk[slot] = 0;
+                                syncStatus10Related[slot] = 0;
+                            }
+                            return;
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+}
+}

--- a/src/OpenSHC/Synchrony/GameSynchronyState/computeSomeHashOnUnitArray.cpp
+++ b/src/OpenSHC/Synchrony/GameSynchronyState/computeSomeHashOnUnitArray.cpp
@@ -1,0 +1,20 @@
+#include "../GameSynchronyState.func.hpp"
+
+#include "OpenSHC/Map/Navigation/DirectionAlgorithmState.func.hpp"
+
+#include "OpenSHC/Globals/DAT_DirectionAlgorithmState.hpp"
+#include "OpenSHC/Globals/DAT_UnitsState.hpp"
+
+namespace OpenSHC {
+namespace Synchrony {
+
+    // FUNCTION: STRONGHOLDCRUSADER 0x0047EEB0
+    int GameSynchronyState::computeSomeHashOnUnitArray()
+    {
+        return MACRO_CALL_MEMBER(
+            Map::Navigation::DirectionAlgorithmState_Func::computeHash, DAT_DirectionAlgorithmState::ptr)(
+            sizeof(DAT_UnitsState::instance.units), reinterpret_cast<int*>(DAT_UnitsState::instance.units));
+    }
+
+}
+}

--- a/src/OpenSHC/Synchrony/GameSynchronyState/sendPeriodicSyncMessages.cpp
+++ b/src/OpenSHC/Synchrony/GameSynchronyState/sendPeriodicSyncMessages.cpp
@@ -1,0 +1,24 @@
+#include "../GameSynchronyState.func.hpp"
+
+namespace OpenSHC {
+namespace Synchrony {
+
+    // FUNCTION: STRONGHOLDCRUSADER 0x0048C750
+    void GameSynchronyState::sendPeriodicSyncMessages()
+    {
+        unsigned int const now = timeGetTime();
+        // The native comparisons use signed, wrapping 32-bit elapsed values.
+        if (static_cast<int>(now - static_cast<unsigned int>(otherTime1)) > 1800) {
+            otherTime1 = now;
+            MACRO_CALL_MEMBER(GameSynchronyState_Func::sendSyncPacket126, this)();
+        }
+        if (static_cast<int>(now - static_cast<unsigned int>(now2)) >= 180) {
+            now2 = now;
+            MACRO_CALL_MEMBER(GameSynchronyState_Func::sendSomeMultiplayerSyncMessageWithType, this)(0);
+            if (syncRelatedCountdown > 0)
+                --syncRelatedCountdown;
+        }
+    }
+
+}
+}

--- a/tools/validation/README.md
+++ b/tools/validation/README.md
@@ -1,0 +1,53 @@
+# Native synchronization checks
+
+These checks compare the compiled C++ implementations with the original
+Crusader and Extreme 1.41 instructions without opening a game process.
+
+Select these three implementations in `cmake/openshc-sources.txt.local` using
+the project's local development workflow, then build `OpenSHC.dll` with
+MSVC 2005 SP1 and the normal optimized configuration:
+
+```text
+src/OpenSHC/Synchrony/GameSynchronyState/checkGameSync.cpp
+src/OpenSHC/Synchrony/GameSynchronyState/sendPeriodicSyncMessages.cpp
+src/OpenSHC/Synchrony/GameSynchronyState/computeSomeHashOnUnitArray.cpp
+```
+
+Install the development Python dependencies `pefile`, `capstone` and `unicorn`,
+then run:
+
+```text
+python tools/validation/check_native_sync.py GAME_DIRECTORY build-RelWithDebInfo/CMakeFiles/OpenSHC.dll.dir/src/OpenSHC/Synchrony/GameSynchronyState
+```
+
+`GAME_DIRECTORY` must contain both supported original executables; their SHA256
+identities are checked first. No game assets or proprietary executable bytes are
+included in this repository.
+
+The checker reads actual COFF function code and relocation records, binds
+resolvers to their native addresses, and compares all 397/91/21 function bytes.
+It also executes each original and compiled routine in isolated x86 emulation:
+
+- 2,376 host-check cases per variant exercise peer identity/exclusion, missing
+  or early samples, equal/different advertised ticks and hashes, pending resync,
+  countdowns and independent receiver/global objects.
+- 2,304 periodic-message cases per variant exercise signed 32-bit elapsed-time
+  comparisons, 180/1800ms thresholds, clock wrap and send callbacks changing
+  the second timer or countdown.
+- Ten unit-buffer hash cases per variant verify the delegated address, length,
+  receiver, return value and calling convention.
+
+All 9,380 cases compare calls and non-stack memory writes and check stack and
+callee-saved register preservation. Only the clock, packet delivery and delegated
+buffer-hash function are stand-ins; this does not validate transport, hash
+generation, resync completion or a full replay. The unit-buffer helper hashes the
+entire unit array; it is distinct from the canonical per-domain multiplayer hash
+calculation, which excludes selected transient fields.
+
+Extreme checks translate the verified later `GameSynchronyState` offsets,
+resolver addresses and the fourfold unit-array capacity before comparison.
+This is evidence against the Extreme native routines, not an Extreme OpenSHC
+DLL build or a change to the project's generated layouts.
+
+Native-bound function bytes and the linked DLL's `reccmp` percentage are separate
+results: resolver indirections and symbol matching remain in the actual DLL.

--- a/tools/validation/check_native_sync.py
+++ b/tools/validation/check_native_sync.py
@@ -1,0 +1,374 @@
+"""Differential original/compiled x86 sync routines. No live process access.
+
+Only clock, send/queue delivery and the delegated unit-buffer hash are stubs.
+Extreme checks translate verified struct offsets/addresses and unit capacity;
+the OpenSHC C++ target remains Crusader, not a built Extreme DLL.
+"""
+
+from pathlib import Path
+import argparse, hashlib, random, struct
+import pefile
+from capstone import Cs, CS_ARCH_X86, CS_MODE_32
+from unicorn import Uc, UC_ARCH_X86, UC_MODE_32, UC_HOOK_CODE, UC_HOOK_MEM_WRITE
+from unicorn import x86_const as reg
+from native_sync_object import function
+
+NAMES = ("checkGameSync", "sendPeriodicSyncMessages", "computeSomeHashOnUnitArray")
+BASE_CODE = 0x4000000
+STOP, CLOCK, STACK = 0x3DF1000, 0x3DF2000, 0x4108000
+
+
+def check(variant, game, objects):
+    extreme = variant == "Extreme"
+    delta = 0x5C490 if extreme else 0
+    base = 0x23547D8 if extreme else 0x191D768
+    file = "Stronghold_Crusader_Extreme.exe" if extreme else "Stronghold Crusader.exe"
+    expected_hash = (
+        "55648e6b05d67d37a5773fe699bbb17a2d6ad4de1bb9dbded9a21caef82bd7fb"
+        if extreme
+        else "3bb0a8c1e72331b3a30a5aa93ed94beca0081b476b04c1960e26d5b45387ac5a"
+    )
+    assert hashlib.sha256((game / file).read_bytes()).hexdigest() == expected_hash, (
+        "Unsupported original executable: " + file
+    )
+    pe = pefile.PE(str(game / file))
+    image = pe.get_memory_mapped_image()
+    entries = dict(
+        zip(
+            NAMES,
+            (
+                (0x48CC10, 0x48C860, 0x47F080)
+                if extreme
+                else (0x48CB00, 0x48C750, 0x47EEB0)
+            ),
+        )
+    )
+    queue = 0x489210 if extreme else 0x489100
+    send126 = 0x4881F0 if extreme else 0x4880E0
+    send0 = 0x487F40 if extreme else 0x487E30
+    hasher = 0x46CF50 if extreme else 0x46CD30
+    clock_import = 0x59E22C if extreme else 0x59E228
+    units = 0x145CA28 if extreme else 0x1387F38
+    direction = 0xEE283C if extreme else 0xEE23BC
+
+    def original(a, n):
+        return image[a - 0x400000 : a - 0x400000 + n]
+
+    uc = Uc(UC_ARCH_X86, UC_MODE_32)
+    uc.mem_map(0x400000, 0x3E00000)
+    for section in pe.sections:
+        uc.mem_write(0x400000 + section.VirtualAddress, section.get_data())
+
+    def put(a, v):
+        uc.mem_write(a, struct.pack("<I", v & 0xFFFFFFFF))
+
+    def get(a):
+        return struct.unpack("<I", uc.mem_read(a, 4))[0]
+
+    put(clock_import, CLOCK)
+    for address, size in ((queue, 4), (send126, 0), (send0, 4), (hasher, 8)):
+        uc.mem_write(address, b"\xc2" + struct.pack("<H", size))
+    uc.mem_write(CLOCK, b"\xc3")
+    disassembler = Cs(CS_ARCH_X86, CS_MODE_32)
+    disassembler.detail = True
+    codes = {}
+    for name in NAMES:
+        object_file = objects / (name + ".cpp.obj")
+        if not object_file.exists():
+            object_file = objects / (name + ".obj")
+        code, relocs = function(object_file, name)
+        for ins in disassembler.disasm(bytes(code), 0):
+            if extreme and ins.disp_size == 4:
+                disp = ins.disp
+                if 0x7C85C <= disp <= 0x109FFF:
+                    disp += delta
+                elif -0x110000 <= disp <= -0x80000:
+                    disp -= delta
+                if disp != ins.disp:
+                    struct.pack_into("<i", code, ins.address + ins.disp_offset, disp)
+        if extreme and name == "computeSomeHashOnUnitArray":
+            assert struct.unpack_from("<I", code, 6)[0] == 0x2C8E40
+            struct.pack_into("<I", code, 6, 0xB23900)
+
+        def bind(entry):
+            result = bytearray(code)
+            for offset, symbol, kind in relocs:
+                addend = struct.unpack_from("<I", result, offset)[0]
+                if kind == 6:
+                    if "GameSynchronyState@" in symbol:
+                        target = base
+                    elif "UnitsState@" in symbol:
+                        target = units
+                    elif "DirectionAlgorithmState@" in symbol:
+                        target = direction
+                    elif symbol == "__imp__timeGetTime@0":
+                        target = clock_import
+                    else:
+                        raise AssertionError(symbol)
+                    struct.pack_into("<I", result, offset, target + addend)
+                elif kind == 20:
+                    target = next(
+                        value
+                        for key, value in {
+                            "queueCommand": queue,
+                            "sendSyncPacket126": send126,
+                            "sendSomeMultiplayerSyncMessageWithType": send0,
+                            "computeHash": hasher,
+                        }.items()
+                        if key in symbol
+                    )
+                    struct.pack_into("<i", result, offset, target - entry - offset - 4)
+                else:
+                    raise AssertionError((symbol, kind))
+            return bytes(result)
+
+        codes[name] = bind(BASE_CODE)
+        assert bind(entries[name]) == original(entries[name], len(code)), (
+            variant,
+            name,
+            "native bytes",
+        )
+        print(
+            variant,
+            name,
+            len(code),
+            "bytes match after native binding/layout translation",
+        )
+
+    offsets = {
+        "halt": 0xB94,
+        "pending": 0xBEC,
+        "countdown": 0x7A870,
+        "host": 0x790,
+        "hashCountdown": 0x1092AC + delta,
+        "delay": 0x109EE8 + delta,
+        "timer126": 0x109ED0 + delta,
+        "timer0": 0x109ED4 + delta,
+    }
+    handles, hashes, times, excluded = 0x6A8, 0x7A898, 0x7A8BC, 0x106DF8 + delta
+    ack, status = 0x101A8C + delta, 0x101AB0 + delta
+    writes = []
+    calls = []
+    current = {}
+
+    def on_write(machine, access, address, size, value, data):
+        if not STACK - 0x1000 <= address < STACK + 0x1000:
+            writes.append((address, size, value & ((1 << (8 * size)) - 1)))
+
+    uc.hook_add(UC_HOOK_MEM_WRITE, on_write)
+
+    def observe(machine, address, size, data):
+        if address == STOP:
+            machine.emu_stop()
+            return
+        if address == CLOCK:
+            machine.reg_write(reg.UC_X86_REG_EAX, current.get("now", 0))
+            return
+        this = current["this"]
+        if address == queue:
+            calls.append(
+                (
+                    "queue",
+                    machine.reg_read(reg.UC_X86_REG_ECX),
+                    get(machine.reg_read(reg.UC_X86_REG_ESP) + 4),
+                    get(this + offsets["pending"]),
+                    get(this + offsets["countdown"]),
+                    get(this + offsets["delay"]),
+                )
+            )
+        if address == send126:
+            calls.append(
+                (
+                    "126",
+                    machine.reg_read(reg.UC_X86_REG_ECX),
+                    get(this + offsets["timer126"]),
+                )
+            )
+            if current.get("mutate") == 1:
+                put(this + offsets["timer0"], current["now"])
+        if address == send0:
+            calls.append(
+                (
+                    "0",
+                    machine.reg_read(reg.UC_X86_REG_ECX),
+                    get(machine.reg_read(reg.UC_X86_REG_ESP) + 4),
+                    get(this + offsets["timer0"]),
+                )
+            )
+            if current.get("mutate") == 2:
+                put(this + offsets["countdown"], 2)
+        if address == hasher:
+            sp = machine.reg_read(reg.UC_X86_REG_ESP)
+            calls.append(
+                ("hash", machine.reg_read(reg.UC_X86_REG_ECX), get(sp + 4), get(sp + 8))
+            )
+            machine.reg_write(reg.UC_X86_REG_EAX, current["return"])
+
+    for address in (STOP, CLOCK, queue, send126, send0, hasher):
+        uc.hook_add(UC_HOOK_CODE, observe, begin=address, end=address)
+
+    def run(name, values, compiled):
+        current.clear()
+        current.update(values)
+        this = values.get("this", base)
+        current["this"] = this
+        fields = {key: values.get(key, 0) for key in offsets}
+        fields.update(halt=37, delay=47)
+        for key, value in fields.items():
+            put(this + offsets[key], value)
+        put(base + offsets["host"], values.get("globalHost", 1))
+        for i in range(9):
+            for start, key, default in (
+                (handles, "handles", -1),
+                (hashes, "hashes", 123),
+                (times, "times", 64),
+                (excluded, "excluded", 0),
+            ):
+                put(this + start + i * 4, values.get(key, [default] * 9)[i])
+            put(this + ack + i * 4, 100 + i)
+            put(this + status + i * 4, 200 + i)
+        writes.clear()
+        calls.clear()
+        entry = BASE_CODE if compiled else entries[name]
+        if compiled:
+            uc.mem_write(BASE_CODE, codes[name])
+            uc.ctl_remove_cache(BASE_CODE, BASE_CODE + len(codes[name]))
+        registers = {
+            "EBX": 0x1111,
+            "ESI": 0x2222,
+            "EDI": 0x3333,
+            "EBP": 0x4444,
+            "ECX": this,
+            "ESP": STACK,
+            "EFLAGS": 0x202,
+        }
+        for key, value in registers.items():
+            uc.reg_write(getattr(reg, "UC_X86_REG_" + key), value)
+        put(STACK, STOP)
+        uc.emu_start(entry, 0, count=10000)
+        assert uc.reg_read(reg.UC_X86_REG_EIP) == STOP, (variant, name, values)
+        assert uc.reg_read(reg.UC_X86_REG_ESP) == STACK + 4
+        for key in ("EBX", "ESI", "EDI", "EBP"):
+            assert uc.reg_read(getattr(reg, "UC_X86_REG_" + key)) == registers[key]
+        result = (calls[:], {a: (s, v) for a, s, v in writes})
+        if name == "computeSomeHashOnUnitArray":
+            result += (uc.reg_read(reg.UC_X86_REG_EAX),)
+        return result
+
+    def compare(name, values):
+        expected = run(name, values, False)
+        actual = run(name, values, True)
+        assert expected == actual, (variant, name, values, expected, actual)
+
+    count = 0
+    for first in range(1, 9):
+        for second in range(1, 9):
+            if first == second:
+                continue
+            for issue in (
+                "equal",
+                "hash",
+                "time",
+                "zero",
+                "early",
+                "excluded",
+                "absent",
+            ):
+                for countdown in (-1, 0, 5):
+                    values = {
+                        "handles": [-1] * 9,
+                        "hashes": [123] * 9,
+                        "times": [64] * 9,
+                        "excluded": [0] * 9,
+                        "countdown": countdown,
+                    }
+                    values["handles"][first] = 11
+                    values["handles"][second] = 22
+                    if issue == "hash":
+                        values["hashes"][second] = 0x80000001
+                    if issue == "time":
+                        values["hashes"][second] = 456
+                        values["times"][second] = 65
+                    if issue == "zero":
+                        values["hashes"][second] = 0
+                    if issue == "early":
+                        values["times"][second] = 9
+                    if issue == "excluded":
+                        values["excluded"][second] = 1
+                        values["hashes"][second] = 456
+                    if issue == "absent":
+                        values["handles"][second] = -1
+                        values["hashes"][second] = 456
+                    compare("checkGameSync", values)
+                    count += 1
+    rng = random.Random(34141)
+    for i in range(1200):
+        values = {
+            "handles": [rng.choice([-1, 0, 17]) for _ in range(9)],
+            "hashes": [
+                rng.choice([0, 11, 22, 0x80000000, 0xFFFFFFFF]) for _ in range(9)
+            ],
+            "times": [rng.choice([0, 9, 10, 64, 65, 0xFFFFFFFF]) for _ in range(9)],
+            "excluded": [rng.randrange(2) for _ in range(9)],
+            "countdown": rng.choice([-1, 0, 5]),
+            "hashCountdown": rng.choice([0, 0, 0, 1, 0xFFFFFFFF]),
+            "pending": rng.choice([0, 0, 1]),
+            "globalHost": rng.randrange(2),
+            "host": rng.randrange(2),
+            "this": base if i % 2 else 0x3000000,
+        }
+        compare("checkGameSync", values)
+        count += 1
+    print(
+        variant,
+        count,
+        "host sync comparison cases, including independent this/global state",
+    )
+    count = 0
+    for now in (17, 10000, 0xFFFFFFF0):
+        for elapsed126 in (0, 179, 180, 1800, 1801, 0x7FFFFFFF, 0x80000000, 0xFFFFFFFF):
+            for elapsed0 in (
+                0,
+                179,
+                180,
+                1800,
+                1801,
+                0x7FFFFFFF,
+                0x80000000,
+                0xFFFFFFFF,
+            ):
+                for countdown in (-1, 0, 1, 5):
+                    for mutate in (0, 1, 2):
+                        compare(
+                            "sendPeriodicSyncMessages",
+                            {
+                                "now": now,
+                                "timer126": now - elapsed126,
+                                "timer0": now - elapsed0,
+                                "countdown": countdown,
+                                "mutate": mutate,
+                            },
+                        )
+                        count += 1
+    print(
+        variant, count, "periodic signed-clock/threshold/wrap/callback mutation cases"
+    )
+    for value in (0, 1, 0x7FFFFFFF, 0x80000000, 0xFFFFFFFF):
+        for this in (base, 0x3000000):
+            compare("computeSomeHashOnUnitArray", {"return": value, "this": this})
+    print(variant, "10 unit-buffer hash delegation/return/ABI cases")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "game", type=Path, help="Directory containing both original 1.41 executables"
+    )
+    parser.add_argument(
+        "objects",
+        type=Path,
+        help="Directory containing the three MSVC x86 object files",
+    )
+    args = parser.parse_args()
+    for variant in ("SHC", "Extreme"):
+        check(variant, args.game, args.objects)

--- a/tools/validation/native_sync_object.py
+++ b/tools/validation/native_sync_object.py
@@ -1,0 +1,37 @@
+import struct
+
+
+def function(path, target):
+    data = path.read_bytes()
+    machine, _, _, sympos, nsymbols, optional, _ = struct.unpack_from("<HHIIIHH", data)
+    assert machine == 0x14C and optional == 0
+    strings = sympos + nsymbols * 18
+    symbols = {}
+    index = 0
+    while index < nsymbols:
+        name, value, section, _, _, aux = struct.unpack_from(
+            "<8sIhHBB", data, sympos + index * 18
+        )
+        if name[:4] == b"\0" * 4:
+            offset = strings + struct.unpack_from("<I", name, 4)[0]
+            name = data[offset : data.index(b"\0", offset)]
+        else:
+            name = name.rstrip(b"\0")
+        symbols[index] = (name.decode(), value, section)
+        index += 1 + aux
+    _, start, section = next(
+        v
+        for v in symbols.values()
+        if v[0].startswith("?" + target + "@GameSynchronyState@")
+    )
+    header = 20 + (section - 1) * 40
+    size, offset, relpos = struct.unpack_from("<III", data, header + 16)
+    nrel = struct.unpack_from("<H", data, header + 32)[0]
+    # /Gy places a single function in this section.
+    assert start == 0
+    code = bytearray(data[offset : offset + size])
+    relocations = []
+    for index in range(nrel):
+        address, symbol, kind = struct.unpack_from("<IIH", data, relpos + index * 10)
+        relocations.append((address, symbols[symbol][0], kind))
+    return code, relocations


### PR DESCRIPTION
**TL;DR:** Reconstruct host synchronization checks and periodic sync messages.

OpenSHC needs readable C++ counterparts for the native host comparison, periodic sender and unit-buffer hash helper.

**Changes:** Implement the three functions through existing resolvers, retaining original timing, peer filtering, receiver identity and acknowledgements.

**Review / testing:** DLL build and 9,380 differential cases were reported passing. Linked reccmp scores are 98.02%, 92.59% and 60.00%. **Outstanding maintainer requests:** update status, use explicit `this->`, remove matching validation files and the redundant validation README. The current diff still contains the validation directory and no status update. The native-bound byte match does not replace those requests.
