### PR TITLE
Reimplement adjacent tile region and height check

### DIFF
--- a/src/OpenSHC/Map/TileMapState/findTileInSameAreaAndNoTooHeightDifference.cpp
+++ b/src/OpenSHC/Map/TileMapState/findTileInSameAreaAndNoTooHeightDifference.cpp
@@ -1,0 +1,24 @@
+#include "../TileMapState.func.hpp"
+
+namespace OpenSHC {
+namespace Map {
+
+    // FUNCTION: STRONGHOLDCRUSADER 0x00500370
+    BOOLEnum TileMapState::findTileInSameAreaAndNoTooHeightDifference(int area, int tile, int row)
+    {
+        int direction = 0;
+        int* neighborOffset = this->directionTranslationMatrix[row];
+        for (; direction < 8; ++direction, ++neighborOffset) {
+            int neighborTile = tile + *neighborOffset;
+            // This is an existence check, not a route search. Lower neighbors have
+            // no height restriction; a neighbor may be at most 16 units higher.
+            if (this->HeightLayer[neighborTile] <= this->HeightLayer[tile] + 16 &&
+                static_cast<short>(this->PathConnectionLayer[neighborTile]) == area) {
+                return TRUE;
+            }
+        }
+        return FALSE;
+    }
+
+} // namespace Map
+} // namespace OpenSHC


### PR DESCRIPTION
**TL;DR:** Reconstruct the native neighboring-tile region and height check.

Moat selection uses this helper to ask whether a neighboring tile belongs to an area within the native height limit.

**Changes:** Implement `TileMapState::findTileInSameAreaAndNoTooHeightDifference` at `0x500370`: examine eight offsets, allow at most 16 units upward and compare the signed region ID.

**Review / testing:** DLL build and 100% effective reccmp were reported; two independent setup instructions have different ordering. **TheRedDaemon requested the matching status-file update, which is still absent from the current diff.** This reconstructs existing behavior rather than changing moat routing.
